### PR TITLE
Fix png files check in Level-Add dialog

### DIFF
--- a/gui/level_dialog.cpp
+++ b/gui/level_dialog.cpp
@@ -123,8 +123,8 @@ void LevelDialog::ok_button_clicked()
           this,
           "If supplied, drawing filename must exist",
           "If supplied, drawing filename must exist");
+      return;
     }
-    return;
   }
   /*
   // todo: figure out how to test for valid numeric values;


### PR DESCRIPTION
Closes #13

Small fix. Only return from the OK callback when the file is not found, but allow the callback to complete if the file exists.

Tested by adding a `png` file to a new level using the dialog. The resulting yaml section looks like this:
```
  L3:
    drawing:
      filename: map.png
    elevation: 0
```
Without this PR when selecting a `png` file on the dialog, and then pressing OK, nothing happens.