### PR TITLE
output nav graphs by name into directory given as param

### DIFF
--- a/building_map_tools/building_map/generator.py
+++ b/building_map_tools/building_map/generator.py
@@ -25,6 +25,7 @@ class Generator:
 
         if not os.path.exists(output_models_dir):
             os.makedirs(output_models_dir)
+
         building.generate_sdf_models(output_models_dir)
         
         # generate a top-level SDF for convenience
@@ -36,17 +37,19 @@ class Generator:
             f.write(sdf_str)
         print(f'{len(sdf_str)} bytes written to {output_filename}')
 
-    def generate_nav(self, input_filename, output_prefix):
+    def generate_nav(self, input_filename, output_dir):
         building = self.parse_editor_yaml(input_filename)
-
         nav_graphs = building.generate_nav_graphs()
 
         class CustomDumper(yaml.Dumper):
             def ignore_aliases(self, _):
                 return True
 
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+
         for graph_name, graph_data in nav_graphs.items():
-            output_filename = f'{output_prefix}_{graph_name}.yaml'
+            output_filename = os.path.join(output_dir, f'{graph_name}.yaml')
             print(f'writing {output_filename}')
             with open(output_filename, 'w') as f:
                 yaml.dump(

--- a/building_map_tools/building_map_generators/building_map_nav.py
+++ b/building_map_tools/building_map_generators/building_map_nav.py
@@ -4,9 +4,9 @@ import building_map
 
 def main():
     if len(sys.argv) != 3:
-        print('usage: building_map_nav INPUT.yaml OUTPUT_PREFIX')
+        print('usage: building_map_nav INPUT.yaml OUTPUT_DIRECTORY')
         sys.exit(1)
     input_filename = sys.argv[1]
-    output_prefix = sys.argv[2]
+    output_dir = sys.argv[2]
     g = building_map.Generator()
-    g.generate_nav(input_filename, output_prefix)
+    g.generate_nav(input_filename, output_dir)


### PR DESCRIPTION
Instead of mashing a prefix followed by `_GRAPHNAME.yaml`, instead the nav graph generator now will take a directory name, and it will generate nav graphs of the form `GRAPHNAME.yaml` into that directory. This is easier to predict for downstream consumers of the graphs.