### PR TITLE
show model pixmaps rotating, with optional discretization

### DIFF
--- a/traffic_editor/gui/editor.h
+++ b/traffic_editor/gui/editor.h
@@ -228,6 +228,9 @@ private:
       const QPointF &p,
       const Polygon::Type &polygon_type);
 
+  QGraphicsPixmapItem *get_closest_pixmap_item(const QPointF &p);
+  double discretize_angle(const double &angle);
+
   void mouse_select(const MouseType t, QMouseEvent *e, const QPointF &p);
   void mouse_add_vertex(const MouseType t, QMouseEvent *e, const QPointF &p);
   void mouse_move_vertex(const MouseType t, QMouseEvent *e, const QPointF &p);

--- a/traffic_editor/gui/map.cpp
+++ b/traffic_editor/gui/map.cpp
@@ -200,19 +200,15 @@ void Map::add_model(
   changed = true;
 }
 
-void Map::rotate_model(
+void Map::set_model_yaw(
     const int level_idx,
     const int model_idx,
-    const double release_x,
-    const double release_y)
+    const double yaw)
 {
   if (level_idx >= static_cast<int>(levels.size()))
     return;
 
-  Model &model = levels[level_idx].models[model_idx];
-  const double dx = release_x - model.x;
-  const double dy = -(release_y - model.y);  // vertical axis is flipped
-  model.yaw = atan2(dy, dx);
+  levels[level_idx].models[model_idx].yaw = yaw;
   changed = true;
 }
 

--- a/traffic_editor/gui/map.h
+++ b/traffic_editor/gui/map.h
@@ -68,11 +68,10 @@ public:
 
   void delete_keypress(const int level_index);
 
-  void rotate_model(
+  void set_model_yaw(
       const int level_idx,
       const int model_idx,
-      const double release_x,
-      const double release_y);
+      const double yaw);
 
   void remove_polygon_vertex(
       const int level_idx,


### PR DESCRIPTION
Using the "rotate model" tool now shows the pixmap model rotating in real-time with mouse motion, as opposed to only showing the rotation circle and "yaw=0" pointer moving. Also, you can hold `Shift` down while rotating, and it will snap to 45-degree discretizations, so it's easier to orient things to look nice.