### PR TITLE
Tweaking limits on doors so they can close

### DIFF
--- a/building_map_tools/building_map/doors/door.py
+++ b/building_map_tools/building_map/doors/door.py
@@ -38,6 +38,15 @@ class Door:
         collision_geometry_ele.append(
             self.box(width, self.thickness, self.height))
 
+        mass = 50.0
+        inertial_ele = SubElement(link_ele, 'inertial')
+        mass_ele = SubElement(inertial_ele, 'mass')
+        mass_ele.text = str(mass)
+        inertia_ele = SubElement(inertial_ele, 'inertia')
+        SubElement(inertia_ele, 'ixx').text = str(mass/12.0*(self.thickness**2 + self.height**2))
+        SubElement(inertia_ele, 'iyy').text = str(mass/12.0*(width**2 + self.height**2))
+        SubElement(inertia_ele, 'izz').text = str(mass/12.0*(self.thickness**2 + width**2))
+
         return link_ele
 
     def generate_sliding_section(self, name, width, x_offset, bounds):

--- a/building_map_tools/building_map/doors/double_sliding_door.py
+++ b/building_map_tools/building_map/doors/double_sliding_door.py
@@ -13,13 +13,13 @@ class DoubleSlidingDoor(Door):
             'left',
             self.length/2 - 0.01,
             -self.length/4,
-            (-self.length/2, 0.01))
+            (-self.length/2, 0.0))
 
         self.generate_sliding_section(
             'right',
             self.length/2 - 0.01,
             self.length/4,
-            (0.01, self.length/2))
+            (0.0, self.length/2))
 
         plugin_ele = SubElement(self.model_ele, 'plugin')
         plugin_ele.set('name', f'plugin_{self.name}')

--- a/building_map_tools/building_map/doors/double_sliding_door.py
+++ b/building_map_tools/building_map/doors/double_sliding_door.py
@@ -26,10 +26,10 @@ class DoubleSlidingDoor(Door):
         plugin_ele.set('filename', 'libdoor.so')
         plugin_params = {
           'v_max_door': '0.2',
-          'a_max_door': '0.1',
+          'a_max_door': '0.2',
           'a_nom_door': '0.08',
           'dx_min_door': '0.001',
-          'f_max_door': '200.0'
+          'f_max_door': '100.0'
         }
         for param_name, param_value in plugin_params.items():
             ele = SubElement(plugin_ele, param_name)

--- a/building_map_tools/building_map/doors/double_swing_door.py
+++ b/building_map_tools/building_map/doors/double_swing_door.py
@@ -28,10 +28,10 @@ class DoubleSwingDoor(Door):
         plugin_ele.set('filename', 'libdoor.so')
         plugin_params = {
           'v_max_door': '0.5',
-          'a_max_door': '0.2',
+          'a_max_door': '0.3',
           'a_nom_door': '0.15',
           'dx_min_door': '0.01',
-          'f_max_door': '100.0'
+          'f_max_door': '500.0'
         }
         for param_name, param_value in plugin_params.items():
             ele = SubElement(plugin_ele, param_name)


### PR DESCRIPTION
The simulated sliding doors were having trouble closing because the `0.01` limit was making them crash into each other.