### PR TITLE
Fiducials to align layers

### DIFF
--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -78,8 +78,38 @@ Editor::Editor(QWidget *parent)
       [=](int row, int /*col*/) {
         if (row < static_cast<int>(map.levels.size()))
         {
+          // save the center point of the current level's image coordinates
+          const QPoint p_center_window(
+              map_view->viewport()->width() / 2,
+              map_view->viewport()->height() / 2);
+          const QPointF p_center_scene = map_view->mapToScene(p_center_window);
+          // printf("p_center_scene: (%.1f, %.1f)\n",
+          //   p_center_scene.x(), p_center_scene.y());
+
+          QPointF p_transformed;
+          map.transform_between_levels(
+              level_idx,
+              p_center_scene,
+              row,
+              p_transformed);
+          // printf("p_transformed: (%.1f, %.1f)\n",
+          //     p_transformed.x(),
+          //     p_transformed.y());
+          
+          // maintain the view scale
+          const double prev_scale = map_view->transform().m11();
+
+          const double scale = prev_scale *
+              map.levels[row].drawing_meters_per_pixel /
+              map.levels[level_idx].drawing_meters_per_pixel;
+
           level_idx = row;
           create_scene();
+
+          QTransform t;
+          t.scale(scale, scale);
+          map_view->setTransform(t);
+          map_view->centerOn(p_transformed);
         }
       });
 

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -1380,8 +1380,14 @@ void Editor::mouse_select(
   {
     // use the QGraphics stuff to see if it's an edge segment or polygon
     QGraphicsItem *item = map_view->itemAt(p.x(), p.y());
+    if (item)
+    {
+      printf("clicked something: type = %d\n", static_cast<int>(item->type()));
+    }
+
     if (item && item->type() == QGraphicsLineItem::Type)
     {
+      printf("clicked line\n");
       set_selected_line_item(
           qgraphicsitem_cast<QGraphicsLineItem *>(item));
     }

--- a/traffic_editor/gui/fiducial.cpp
+++ b/traffic_editor/gui/fiducial.cpp
@@ -79,3 +79,10 @@ void Fiducial::draw(
     item->setPos(x, y + radius);
   }
 }
+
+double Fiducial::distance(const Fiducial& f)
+{
+  const double dx = f.x - x;
+  const double dy = f.y - y;
+  return sqrt(dx*dx + dy*dy);
+}

--- a/traffic_editor/gui/fiducial.h
+++ b/traffic_editor/gui/fiducial.h
@@ -42,6 +42,8 @@ public:
   YAML::Node to_yaml() const;
 
   void draw(QGraphicsScene *, const double meters_per_pixel) const;
+
+  double distance(const Fiducial& f);
 };
 
 #endif

--- a/traffic_editor/gui/lift.cpp
+++ b/traffic_editor/gui/lift.cpp
@@ -113,7 +113,9 @@ void Lift::draw(
     QGraphicsScene *scene,
     const double meters_per_pixel,
     const string& /*level_name*/,
-    const bool apply_transformation) const
+    const bool apply_transformation,
+    const double translate_x,
+    const double translate_y) const
 {
   const double cabin_w = width / meters_per_pixel;
   const double cabin_d = depth / meters_per_pixel;
@@ -172,7 +174,7 @@ void Lift::draw(
   if (apply_transformation)
   {
     group->setRotation(-180.0 / 3.1415926 * yaw);
-    group->setPos(x, y);
+    group->setPos(x + translate_x, y + translate_y);
   }
 }
 

--- a/traffic_editor/gui/lift.cpp
+++ b/traffic_editor/gui/lift.cpp
@@ -114,6 +114,7 @@ void Lift::draw(
     const double meters_per_pixel,
     const string& /*level_name*/,
     const bool apply_transformation,
+    const double scale,
     const double translate_x,
     const double translate_y) const
 {
@@ -174,7 +175,7 @@ void Lift::draw(
   if (apply_transformation)
   {
     group->setRotation(-180.0 / 3.1415926 * yaw);
-    group->setPos(x + translate_x, y + translate_y);
+    group->setPos(x * scale + translate_x, y * scale + translate_y);
   }
 }
 

--- a/traffic_editor/gui/lift.h
+++ b/traffic_editor/gui/lift.h
@@ -74,6 +74,7 @@ public:
       const double meters_per_pixel,
       const std::string& level_name,
       const bool apply_transformation = true,
+      const double scale = 1.0,
       const double translate_x = 0.0,
       const double translate_y = 0.0) const;
 

--- a/traffic_editor/gui/lift.h
+++ b/traffic_editor/gui/lift.h
@@ -73,7 +73,9 @@ public:
       QGraphicsScene *scene,
       const double meters_per_pixel,
       const std::string& level_name,
-      const bool apply_transformation = true) const;
+      const bool apply_transformation = true,
+      const double translate_x = 0.0,
+      const double translate_y = 0.0) const;
 
   bool level_door_opens(
       const std::string& level_name,

--- a/traffic_editor/gui/lift_dialog.cpp
+++ b/traffic_editor/gui/lift_dialog.cpp
@@ -420,5 +420,5 @@ void LiftDialog::door_table_cell_changed(int row, int col)
 void LiftDialog::update_lift_view()
 {
   _lift_scene->clear();
-  _lift.draw(_lift_scene, 0.005, std::string(), false);
+  _lift.draw(_lift_scene, 0.01, std::string(), false);
 }

--- a/traffic_editor/gui/lift_dialog.cpp
+++ b/traffic_editor/gui/lift_dialog.cpp
@@ -247,9 +247,13 @@ void LiftDialog::ok_button_clicked()
   }
 
   _lift.name = _name_line_edit->text().toStdString();
+  _lift.reference_floor_name =
+      _reference_floor_combo_box->currentText().toStdString();
+
   _lift.x = _x_line_edit->text().toDouble();
   _lift.y = _y_line_edit->text().toDouble();
   _lift.yaw = _yaw_line_edit->text().toDouble();
+
   _lift.width = _width_line_edit->text().toDouble();
   _lift.depth = _depth_line_edit->text().toDouble();
 

--- a/traffic_editor/gui/map.cpp
+++ b/traffic_editor/gui/map.cpp
@@ -25,8 +25,7 @@
 #include <QDir>
 
 using std::string;
-using std::cout;
-using std::endl;
+using std::vector;
 
 
 Map::Map()
@@ -509,6 +508,19 @@ Map::Transform Map::compute_transform(
   printf("  scales: from %.3f  to: %.3f\n",
       from_level.drawing_meters_per_pixel, 
       to_level.drawing_meters_per_pixel);
+
+  // assemble a vector of fudicials in common to these levels
+  vector< std::pair<Fiducial, Fiducial> > fiducial_pairs;
+  for (const Fiducial& f0 : from_level.fiducials)
+    for (const Fiducial& f1 : to_level.fiducials)
+    {
+      if (f0.name == f1.name)
+      {
+        fiducial_pairs.push_back(make_pair(f0, f1));
+        break;
+      }
+    }
+  printf("%d fiducials in common\n", static_cast<int>(fiducial_pairs.size()));
 
   // for now, we assume that the maps are already rotated identically
   // and we only need to compute the 2d translation between them

--- a/traffic_editor/gui/map.cpp
+++ b/traffic_editor/gui/map.cpp
@@ -403,9 +403,208 @@ void Map::write_yaml_node(const YAML::Node& node, YAML::Emitter& emitter)
   }
 }
 
-void Map::draw_lifts(QGraphicsScene *scene, const int level_idx) const
+void Map::draw_lifts(QGraphicsScene *scene, const int level_idx)
 {
   const Level& level = levels[level_idx];
   for (const auto &lift : lifts)
-    lift.draw(scene, level.drawing_meters_per_pixel, level.name);
+  {
+    // find the level index referenced by the lift
+    int reference_floor_idx = -1;
+    for (size_t i = 0; i < levels.size(); i++)
+      if (levels[i].name == lift.reference_floor_name)
+      {
+        reference_floor_idx = static_cast<int>(i);
+        break;
+      }
+
+    Transform t;
+    if (reference_floor_idx >= 0)
+    {
+      t = get_transform(reference_floor_idx, level_idx);
+      double level_scale = level.drawing_meters_per_pixel;
+      double ref_scale = levels[reference_floor_idx].drawing_meters_per_pixel;
+      printf("scale: %.3f   ref_scale: %.3f    t = (%.1f, %.1f)\n",
+          level_scale,
+          ref_scale,
+          t.dx,
+          t.dy);
+
+      //double scale_diff =
+      //    level.meters_per_pixel / 
+    }
+
+    lift.draw(
+        scene,
+        level.drawing_meters_per_pixel,
+        level.name,
+        true,
+        t.dx,
+        t.dy);
+  }
+}
+
+bool Map::transform_between_levels(
+    const std::string& from_level_name,
+    const QPointF& from_point,
+    const std::string& to_level_name,
+    QPointF& to_point)
+{
+  int from_level_idx = -1;
+  int to_level_idx = -1;
+  for (size_t i = 0; i < levels.size(); i++)
+  {
+    if (levels[i].name == from_level_name)
+      from_level_idx = i;
+    if (levels[i].name == to_level_name)
+      to_level_idx = i;
+  }
+  if (from_level_idx < 0 || to_level_idx < 0)
+  {
+    to_point = from_point;
+    return false;
+  }
+  return transform_between_levels(
+      from_level_idx,
+      from_point,
+      to_level_idx,
+      to_point);
+}
+
+bool Map::transform_between_levels(
+    const int from_level_idx,
+    const QPointF& from_point,
+    const int to_level_idx,
+    QPointF& to_point)
+{
+
+  if (from_level_idx < 0 ||
+      from_level_idx >= static_cast<int>(levels.size()) ||
+      to_level_idx < 0 ||
+      to_level_idx >= static_cast<int>(levels.size()))
+  {
+    to_point = from_point;
+    return false;
+  }
+
+  const Transform t = get_transform(from_level_idx, to_level_idx);
+
+  to_point.rx() = from_point.x() + t.dx;
+  to_point.ry() = from_point.y() + t.dy;
+  return true;
+}
+
+void Map::clear_transform_cache()
+{
+  transforms.clear();
+}
+
+Map::Transform Map::compute_transform(
+    const int from_level_idx,
+    const int to_level_idx)
+{
+  // this internal function assumes that bounds checking has already happened
+  const Level& from_level = levels[from_level_idx];
+  const Level& to_level = levels[to_level_idx];
+
+  printf("  scales: from %.3f  to: %.3f\n",
+      from_level.drawing_meters_per_pixel, 
+      to_level.drawing_meters_per_pixel);
+
+  // for now, we assume that the maps are already rotated identically
+  // and we only need to compute the 2d translation between them
+  // first we will gather all the dx and dy estimates
+  std::vector<double> dx_est, dy_est;
+
+  // we also assume that the maps have already been scaled correctly (!)
+
+  // look up all fiducials in common between these levels
+  for (const Fiducial& f_from : from_level.fiducials)
+    for (const Fiducial& f_to : to_level.fiducials)
+      if (f_from.name == f_to.name)
+      {
+        const double from_x_meters =
+            f_from.x * from_level.drawing_meters_per_pixel;
+        const double from_y_meters =
+            f_from.y * from_level.drawing_meters_per_pixel;
+
+        const double to_x_meters =
+            f_to.x * from_level.drawing_meters_per_pixel;
+        const double to_y_meters =
+            f_to.y * from_level.drawing_meters_per_pixel;
+
+        dx_est.push_back(to_x_meters - from_x_meters);
+        dy_est.push_back(to_y_meters - from_y_meters);
+        printf("  %s: (%.1f, %.1f)   from: (%.1f, %.1f)   to: (%.1f, %.1f)\n",
+            f_from.name.c_str(),
+            dx_est.back(),
+            dy_est.back(),
+            from_x_meters,
+            from_y_meters,
+            to_x_meters,
+            to_y_meters);
+        break;
+      }
+
+  printf("matched %d fiducials between level indices %d and %d\n",
+      static_cast<int>(dx_est.size()), from_level_idx, to_level_idx);
+
+  // for now just do arithmetic mean. we can get more sophisticated later.
+  double x_mean = 0;
+  double y_mean = 0;
+
+  for (size_t i = 0; i < dx_est.size(); i++)
+  {
+    x_mean += dx_est[i];
+    y_mean += dy_est[i];
+  }
+  x_mean /= static_cast<int>(dx_est.size());
+  y_mean /= static_cast<int>(dy_est.size());
+
+  // compute standard deviation as sanity-check
+  double x_std_dev = 0;
+  double y_std_dev = 0;
+  for (size_t i = 0; i < dx_est.size(); i++)
+  {
+    x_std_dev += (dx_est[i] - x_mean) * (dx_est[i] - x_mean);
+    y_std_dev += (dy_est[i] - y_mean) * (dy_est[i] - y_mean);
+  }
+  x_std_dev /= static_cast<int>(dx_est.size());
+  y_std_dev /= static_cast<int>(dy_est.size());
+
+  printf("  mean: (%.1f, %.1f)  std dev: (%.1f, %.1f)\n",
+      x_mean,
+      y_mean,
+      x_std_dev,
+      y_std_dev);
+
+  Map::Transform t;
+  t.dx = x_mean;
+  t.dy = y_mean;
+
+  return t;
+}
+
+Map::Transform Map::get_transform(
+      const int from_level_idx,
+      const int to_level_idx)
+{
+  // this operation is a bit "heavy" so we'll cache the transformations
+  // as they are computed
+  LevelPair level_pair;
+  level_pair.from_idx = from_level_idx;
+  level_pair.to_idx = to_level_idx;
+
+  TransformMap::iterator transform_it = transforms.find(level_pair);
+  Transform t;
+
+  if (transform_it == transforms.end())
+  {
+    // the transform wasn't in the cache, so we need to actually compute it now
+    t = compute_transform(from_level_idx, to_level_idx);
+    transforms[level_pair] = t;
+  }
+  else
+    t = transform_it->second;
+
+  return t;
 }

--- a/traffic_editor/gui/map.h
+++ b/traffic_editor/gui/map.h
@@ -137,10 +137,12 @@ public:
     }
   };
 
+  // to apply transform: first scale, then translate
   struct Transform
   {
-    double dx = 0;
-    double dy = 0;
+    double scale = 1.0;
+    double dx = 0.0;
+    double dy = 0.0;
   };
   typedef std::map<LevelPair, Transform> TransformMap;
   TransformMap transforms;
@@ -156,7 +158,6 @@ public:
 private:
   // Recursive function to write YAML ordered maps. Credit: Dave Hershberger
   void write_yaml_node(const YAML::Node& node, YAML::Emitter& emitter);
-
 };
 
 #endif

--- a/traffic_editor/gui/map.h
+++ b/traffic_editor/gui/map.h
@@ -25,6 +25,8 @@ class QGraphicsScene;
 #include <vector>
 #include <yaml-cpp/yaml.h>
 
+#include <QPointF>
+
 #include "level.h"
 #include "lift.h"
 
@@ -108,11 +110,53 @@ public:
       const double x,
       const double y);
 
-  void draw_lifts(QGraphicsScene *scene, const int level_idx) const;
+  void draw_lifts(QGraphicsScene *scene, const int level_idx);
+
+  bool transform_between_levels(
+      const std::string& from_level_name,
+      const QPointF& from_point,
+      const std::string& to_level_name,
+      QPointF& to_point);
+
+  bool transform_between_levels(
+      const int from_level_idx,
+      const QPointF& from_point,
+      const int to_level_idx,
+      QPointF& to_point);
+
+  void clear_transform_cache();
+
+  struct LevelPair
+  {
+    int from_idx = -1;
+    int to_idx = -1;
+
+    bool operator<(const LevelPair& rhs) const
+    {
+      return std::tie(from_idx, to_idx) < std::tie(rhs.from_idx, rhs.to_idx);
+    }
+  };
+
+  struct Transform
+  {
+    double dx = 0;
+    double dy = 0;
+  };
+  typedef std::map<LevelPair, Transform> TransformMap;
+  TransformMap transforms;
+
+  Transform compute_transform(
+      const int from_level_idx,
+      const int to_level_idx);
+
+  Transform get_transform(
+      const int from_level_idx,
+      const int to_level_idx);
 
 private:
   // Recursive function to write YAML ordered maps. Credit: Dave Hershberger
   void write_yaml_node(const YAML::Node& node, YAML::Emitter& emitter);
+
 };
 
 #endif


### PR DESCRIPTION
 * fiducial tool to specify easily-identifiable elements on floor plans (support pillars, etc.) to align the drawings of each level of a building. Currently assumes that the drawings are all rotated the same orientation, which is usually the case (so far at least) in what we've seen.
 * use the level alignments to render the lift cabins correctly in all layers. Lift cabins are annotated manually against a "reference" level (for example, the basement) and then automatically translated/scaled to render correctly in all layers
 * use the level alignments to keep the center of the viewport in the same location when switching between levels. This makes it much easier to verify lift doors are in the correct locations on all levels, etc.
 * cache the transformations between levels, since they take a bit of time to calculate.