### PR TITLE
Calculate and show scale using fiducials

### DIFF
--- a/traffic_editor/CMakeLists.txt
+++ b/traffic_editor/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(traffic-editor
   gui/layer_dialog.cpp
   gui/level.cpp
   gui/level_dialog.cpp
+  gui/level_table.cpp
   gui/lift.cpp
   gui/lift_dialog.cpp
   gui/lift_door.cpp

--- a/traffic_editor/CMakeLists.txt
+++ b/traffic_editor/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(traffic-editor
   gui/lift_table.cpp
   gui/main.cpp
   gui/map.cpp
+  gui/map_dialog.cpp
   gui/map_view.cpp
   gui/model.cpp
   gui/model_dialog.cpp

--- a/traffic_editor/gui/add_param_dialog.cpp
+++ b/traffic_editor/gui/add_param_dialog.cpp
@@ -31,7 +31,7 @@ AddParamDialog::AddParamDialog(
   QHBoxLayout *name_hbox_layout = new QHBoxLayout;
   name_hbox_layout->addWidget(new QLabel("name:"));
   name_combo_box = new QComboBox;
-  for (const auto & param_name : param_names)
+  for (const auto& param_name : param_names)
     name_combo_box->addItem(QString::fromStdString(param_name.first));
   name_hbox_layout->addWidget(name_combo_box);
 

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -33,6 +33,7 @@
 #include "level_dialog.h"
 #include "layer_dialog.h"
 #include "lift_table.h"
+#include "map_dialog.h"
 #include "model_dialog.h"
 #include "preferences_dialog.h"
 #include "preferences_keys.h"
@@ -201,6 +202,11 @@ Editor::Editor(QWidget *parent)
 
   // EDIT MENU
   QMenu *edit_menu = menuBar()->addMenu("&Edit");
+  edit_menu->addAction(
+      "&Map properties...",
+      this,
+      &Editor::edit_map_properties);
+  edit_menu->addSeparator();
   edit_menu->addAction("&Preferences...", this, &Editor::edit_preferences);
 
   // VIEW MENU
@@ -459,6 +465,13 @@ void Editor::edit_preferences()
 
   if (preferences_dialog.exec() == QDialog::Accepted)
     load_model_names();
+}
+
+void Editor::edit_map_properties()
+{
+  MapDialog map_dialog(map);
+  if (map_dialog.exec() == QDialog::Accepted)
+    setWindowModified(true);
 }
 
 void Editor::zoom_fit()

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -110,6 +110,12 @@ Editor::Editor(QWidget *parent)
         }
       });
 
+  connect(
+      level_table,
+      &LevelTable::redraw_scene,
+      this,
+      &Editor::create_scene);
+
   lift_table = new LiftTable;
   connect(
       lift_table, &TableList::redraw,
@@ -397,7 +403,7 @@ void Editor::new_map()
   map.clear();
   create_scene();
   save();
-  populate_levels_table();
+  level_table->update(map);
 
   QSettings settings;
   settings.setValue(

--- a/traffic_editor/gui/editor.h
+++ b/traffic_editor/gui/editor.h
@@ -36,6 +36,7 @@ class Level;
 #include "./map.h"
 #include "editor_model.h"
 #include "lift_table.h"
+#include "level_table.h"
 
 QT_BEGIN_NAMESPACE
 class QAction;
@@ -154,10 +155,8 @@ private:
   void layer_edit_button_clicked(const std::string &label);
   void layer_add_button_clicked();
 
-  QTableWidget *levels_table;
-  void populate_levels_table();
-
   LiftTable *lift_table;
+  LevelTable *level_table;
 
   QTableWidget *property_editor;
   void update_property_editor();

--- a/traffic_editor/gui/editor.h
+++ b/traffic_editor/gui/editor.h
@@ -104,6 +104,7 @@ private slots:
 private:
   bool maybe_save();
   void edit_preferences();
+  void edit_map_properties();
 
   void level_add();
   void level_edit();

--- a/traffic_editor/gui/level_dialog.cpp
+++ b/traffic_editor/gui/level_dialog.cpp
@@ -19,9 +19,8 @@
 #include <QtWidgets>
 
 
-LevelDialog::LevelDialog(QWidget *parent, Level &_level)
-: QDialog(parent),
-  level(_level)
+LevelDialog::LevelDialog(Level &_level)
+: level(_level)
 {
   ok_button = new QPushButton("OK", this);  // first button = [enter] button
   cancel_button = new QPushButton("Cancel", this);

--- a/traffic_editor/gui/level_dialog.h
+++ b/traffic_editor/gui/level_dialog.h
@@ -26,7 +26,7 @@ class QLineEdit;
 class LevelDialog : public QDialog
 {
 public:
-  LevelDialog(QWidget *parent, Level &_level);
+  LevelDialog(Level &_level);
   ~LevelDialog();
  
 private:

--- a/traffic_editor/gui/level_table.cpp
+++ b/traffic_editor/gui/level_table.cpp
@@ -96,6 +96,7 @@ void LevelTable::update(Map& map)
         if (level_dialog.exec() == QDialog::Accepted)
         {
           map.add_level(level);
+          emit redraw_scene();
           setWindowModified(true);
         }
       });

--- a/traffic_editor/gui/level_table.cpp
+++ b/traffic_editor/gui/level_table.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2019-2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "level_table.h"
+#include "level_dialog.h"
+#include <QtWidgets>
+
+LevelTable::LevelTable()
+: TableList(5)
+{
+  const QStringList labels = { "Name", "Scale", "Meas", "Fiducials", "" };
+  setHorizontalHeaderLabels(labels);
+}
+
+LevelTable::~LevelTable()
+{
+}
+
+void LevelTable::update(Map& map)
+{
+  blockSignals(true);  // avoid tons of callbacks
+
+  setRowCount(1 + map.levels.size());
+  for (size_t i = 0; i < map.levels.size(); i++)
+  {
+    setItem(
+        i,
+        0,
+        new QTableWidgetItem(QString::fromStdString(map.levels[i].name)));
+
+    setItem(
+        i,
+        1,
+        new QTableWidgetItem(
+            QString::number(
+                map.levels[i].drawing_meters_per_pixel,
+                'g',
+                4)));
+
+    int nmeas = 0;
+    for (const auto& edge : map.levels[i].edges)
+      if (edge.type == Edge::MEAS)
+        nmeas++;
+    setItem(i, 2, new QTableWidgetItem(QString::number(nmeas)));
+
+    setItem(
+        i,
+        3,
+        new QTableWidgetItem(
+            QString::number(map.levels[i].fiducials.size())));
+
+    QPushButton *edit_button = new QPushButton("Edit...", this);
+    setCellWidget(i, 4, edit_button);
+    edit_button->setStyleSheet("QTableWidgetItem { background-color: red; }");
+
+    connect(
+        edit_button, &QAbstractButton::clicked,
+        [this, &map, i]()
+        {
+          LevelDialog level_dialog(map.levels[i]);
+          if (level_dialog.exec() == QDialog::Accepted)
+          {
+            QMessageBox::about(
+                this,
+                "work in progress", "TODO: use this data...sorry.");
+            setWindowModified(true);
+          }
+        });
+  }
+
+  const int last_row_idx = static_cast<int>(map.levels.size());
+  // we'll use the last row for the "Add" button
+  setCellWidget(last_row_idx, 0, nullptr);
+  QPushButton *add_button = new QPushButton("Add...", this);
+  setCellWidget(last_row_idx, 4, add_button);
+  connect(
+      add_button, &QAbstractButton::clicked,
+      [this, &map]()
+      {
+        Level level;
+        LevelDialog level_dialog(level);
+        if (level_dialog.exec() == QDialog::Accepted)
+        {
+          map.add_level(level);
+          setWindowModified(true);
+        }
+      });
+
+  blockSignals(false);
+}

--- a/traffic_editor/gui/level_table.cpp
+++ b/traffic_editor/gui/level_table.cpp
@@ -22,7 +22,8 @@
 LevelTable::LevelTable()
 : TableList(5)
 {
-  const QStringList labels = { "Name", "Scale", "Meas", "Fiducials", "" };
+  const QStringList labels =
+      { "Name", "Elevation", "Scale", "Translation", "" };
   setHorizontalHeaderLabels(labels);
 }
 
@@ -46,11 +47,29 @@ void LevelTable::update(Map& map)
         i,
         1,
         new QTableWidgetItem(
+            QString::number(map.levels[i].elevation, 'g', 1)));
+
+    setItem(
+        i,
+        2,
+        new QTableWidgetItem(
             QString::number(
                 map.levels[i].drawing_meters_per_pixel,
                 'g',
                 4)));
 
+    QString translation_string;
+    if (map.levels[i].name == map.reference_level_name)
+    {
+      translation_string = "[reference]";
+    }
+    else
+    {
+    }
+
+    setItem(i, 3, new QTableWidgetItem(translation_string));
+
+    /*
     int nmeas = 0;
     for (const auto& edge : map.levels[i].edges)
       if (edge.type == Edge::MEAS)
@@ -62,6 +81,7 @@ void LevelTable::update(Map& map)
         3,
         new QTableWidgetItem(
             QString::number(map.levels[i].fiducials.size())));
+    */
 
     QPushButton *edit_button = new QPushButton("Edit...", this);
     setCellWidget(i, 4, edit_button);

--- a/traffic_editor/gui/level_table.h
+++ b/traffic_editor/gui/level_table.h
@@ -25,11 +25,16 @@
 
 class LevelTable : public TableList
 {
+  Q_OBJECT
+
 public:
   LevelTable();
   ~LevelTable();
 
   void update(Map& map);
+
+signals:
+  void redraw_scene();
 };
 
 #endif

--- a/traffic_editor/gui/level_table.h
+++ b/traffic_editor/gui/level_table.h
@@ -15,21 +15,21 @@
  *
 */
 
-#ifndef TABLE_LIST_H
-#define TABLE_LIST_H
+#ifndef LEVEL_TABLE_H
+#define LEVEL_TABLE_H
 
 #include <QTableWidget>
 
-class TableList : public QTableWidget
+#include "table_list.h"
+#include "map.h"
+
+class LevelTable : public TableList
 {
-  Q_OBJECT
-
 public:
-  TableList(const int num_cols = 2);
-  ~TableList();
+  LevelTable();
+  ~LevelTable();
 
-signals:
-  void redraw();
+  void update(Map& map);
 };
 
 #endif

--- a/traffic_editor/gui/lift_table.cpp
+++ b/traffic_editor/gui/lift_table.cpp
@@ -22,6 +22,8 @@
 LiftTable::LiftTable()
 : TableList()
 {
+  const QStringList labels = { "Name", "" };
+  setHorizontalHeaderLabels(labels);
 }
 
 LiftTable::~LiftTable()

--- a/traffic_editor/gui/map.cpp
+++ b/traffic_editor/gui/map.cpp
@@ -573,3 +573,11 @@ Map::Transform Map::get_transform(
 
   return t;
 }
+
+void Map::calculate_all_transforms()
+{
+  clear_transform_cache();
+  for (size_t i = 0; i < levels.size(); i++)
+    for (size_t j = 0; j < levels.size(); j++)
+      get_transform(i, j);
+}

--- a/traffic_editor/gui/map.cpp
+++ b/traffic_editor/gui/map.cpp
@@ -84,6 +84,7 @@ void Map::load_yaml(const string &filename)
     }
   }
 
+  calculate_all_transforms();
   changed = false;
 }
 
@@ -497,9 +498,6 @@ Map::Transform Map::compute_transform(
     const int from_level_idx,
     const int to_level_idx)
 {
-  printf("\n\ncomputing transform from level %d to level %d\n",
-      from_level_idx,
-      to_level_idx);
   // this internal function assumes that bounds checking has already happened
   const Level& from_level = levels[from_level_idx];
   const Level& to_level = levels[to_level_idx];
@@ -547,7 +545,9 @@ Map::Transform Map::compute_transform(
   t.dx = trans_x;
   t.dy = trans_y;
 
-  printf("transform estimate: scale = %.5f   translation = (%.2f, %.2f)\n",
+  printf("transform %d->%d: scale = %.5f translation = (%.2f, %.2f)\n",
+      from_level_idx,
+      to_level_idx,
       t.scale,
       t.dx,
       t.dy);
@@ -570,7 +570,7 @@ Map::Transform Map::get_transform(
 
   if (transform_it == transforms.end())
   {
-    // the transform wasn't in the cache, so we need to actually compute it now
+    // the transform wasn't in the cache, so we need to compute it
     t = compute_transform(from_level_idx, to_level_idx);
     transforms[level_pair] = t;
   }
@@ -586,4 +586,26 @@ void Map::calculate_all_transforms()
   for (size_t i = 0; i < levels.size(); i++)
     for (size_t j = 0; j < levels.size(); j++)
       get_transform(i, j);
+
+  // set drawing scale using this data
+  const int ref_idx = get_reference_level_idx();
+  const double ref_scale = levels[ref_idx].drawing_meters_per_pixel;
+  for (int i = 0; i < static_cast<int>(levels.size()); i++)
+  {
+    if (i != get_reference_level_idx())
+    {
+      Transform t = get_transform(ref_idx, i);
+      levels[i].drawing_meters_per_pixel = ref_scale / t.scale;
+    }
+  }
+}
+
+int Map::get_reference_level_idx()
+{
+  if (reference_level_name.empty())
+    return 0;
+  for (size_t i = 0; i < levels.size(); i++)
+    if (levels[i].name == reference_level_name)
+      return static_cast<int>(i);
+  return 0;
 }

--- a/traffic_editor/gui/map.cpp
+++ b/traffic_editor/gui/map.cpp
@@ -58,6 +58,9 @@ void Map::load_yaml(const string &filename)
   if (y["building_name"])
     building_name = y["building_name"].as<string>();
 
+  if (y["reference_level_name"])
+    reference_level_name = y["reference_level_name"].as<string>();
+
   if (!y["levels"] || !y["levels"].IsMap())
     throw std::runtime_error("expected top-level dictionary named 'levels'");
 
@@ -90,6 +93,9 @@ bool Map::save_yaml(const std::string &filename)
 
   YAML::Node y;
   y["building_name"] = building_name;
+
+  if (!reference_level_name.empty())
+    y["reference_level_name"] = reference_level_name;
 
   y["levels"] = YAML::Node(YAML::NodeType::Map);
   for (const auto &level : levels)

--- a/traffic_editor/gui/map.h
+++ b/traffic_editor/gui/map.h
@@ -158,6 +158,8 @@ public:
 
   void calculate_all_transforms();
 
+  int get_reference_level_idx();
+
 private:
   // Recursive function to write YAML ordered maps. Credit: Dave Hershberger
   void write_yaml_node(const YAML::Node& node, YAML::Emitter& emitter);

--- a/traffic_editor/gui/map.h
+++ b/traffic_editor/gui/map.h
@@ -44,6 +44,7 @@ public:
   std::string building_name;
   std::vector<Level> levels;
   std::vector<Lift> lifts;
+  std::string reference_level_name;
   bool changed;  // true if map changed since last save/open
 
   void add_level(const Level &level);

--- a/traffic_editor/gui/map.h
+++ b/traffic_editor/gui/map.h
@@ -155,6 +155,8 @@ public:
       const int from_level_idx,
       const int to_level_idx);
 
+  void calculate_all_transforms();
+
 private:
   // Recursive function to write YAML ordered maps. Credit: Dave Hershberger
   void write_yaml_node(const YAML::Node& node, YAML::Emitter& emitter);

--- a/traffic_editor/gui/map_dialog.cpp
+++ b/traffic_editor/gui/map_dialog.cpp
@@ -32,12 +32,15 @@ MapDialog::MapDialog(Map& map)
       this);
   building_name_hbox->addWidget(_building_name_line_edit);
 
-  /////////////////////////////////////////////
-
-  // TODO: combo box to select the reference level used to derive the
-  // coordinate system of the generated model(s)
-
-  /////////////////////////////////////////////
+  QHBoxLayout *reference_level_hbox = new QHBoxLayout;
+  reference_level_hbox->addWidget(new QLabel("Reference level:"));
+  _reference_floor_combo_box = new QComboBox;
+  for (const auto& level : map.levels)
+    _reference_floor_combo_box->addItem(QString::fromStdString(level.name));
+  if (!map.levels.empty() && !map.reference_level_name.empty())
+    _reference_floor_combo_box->setCurrentText(
+        QString::fromStdString(map.reference_level_name));
+  reference_level_hbox->addWidget(_reference_floor_combo_box);
 
   QHBoxLayout *bottom_buttons_hbox = new QHBoxLayout;
   bottom_buttons_hbox->addWidget(_cancel_button);
@@ -52,6 +55,7 @@ MapDialog::MapDialog(Map& map)
   QVBoxLayout *top_vbox = new QVBoxLayout;
 
   top_vbox->addLayout(building_name_hbox);
+  top_vbox->addLayout(reference_level_hbox);
   // todo: some sort of separator (?)
   top_vbox->addLayout(bottom_buttons_hbox);
 
@@ -65,5 +69,7 @@ MapDialog::~MapDialog()
 void MapDialog::ok_button_clicked()
 {
   _map.building_name = _building_name_line_edit->text().toStdString();
+  _map.reference_level_name =
+      _reference_floor_combo_box->currentText().toStdString();
   accept();
 }

--- a/traffic_editor/gui/map_dialog.cpp
+++ b/traffic_editor/gui/map_dialog.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2019-2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "map_dialog.h"
+#include <QtWidgets>
+
+
+MapDialog::MapDialog(Map& map)
+: QDialog(), _map(map)
+{
+  _ok_button = new QPushButton("OK", this);  // first button = [enter] button
+  _cancel_button = new QPushButton("Cancel", this);
+
+  QHBoxLayout *building_name_hbox = new QHBoxLayout;
+  building_name_hbox->addWidget(new QLabel("Building name:"));
+  _building_name_line_edit = new QLineEdit(
+      QString::fromStdString(map.building_name),
+      this);
+  building_name_hbox->addWidget(_building_name_line_edit);
+
+  /////////////////////////////////////////////
+
+  // TODO: combo box to select the reference level used to derive the
+  // coordinate system of the generated model(s)
+
+  /////////////////////////////////////////////
+
+  QHBoxLayout *bottom_buttons_hbox = new QHBoxLayout;
+  bottom_buttons_hbox->addWidget(_cancel_button);
+  bottom_buttons_hbox->addWidget(_ok_button);
+  connect(
+      _ok_button, &QAbstractButton::clicked,
+      this, &MapDialog::ok_button_clicked);
+  connect(
+      _cancel_button, &QAbstractButton::clicked,
+      this, &QDialog::reject);
+
+  QVBoxLayout *top_vbox = new QVBoxLayout;
+
+  top_vbox->addLayout(building_name_hbox);
+  // todo: some sort of separator (?)
+  top_vbox->addLayout(bottom_buttons_hbox);
+
+  setLayout(top_vbox);
+}
+
+MapDialog::~MapDialog()
+{
+}
+
+void MapDialog::ok_button_clicked()
+{
+  _map.building_name = _building_name_line_edit->text().toStdString();
+  accept();
+}

--- a/traffic_editor/gui/map_dialog.h
+++ b/traffic_editor/gui/map_dialog.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Open Source Robotics Foundation
+ * Copyright (C) 2019-2020 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,34 +15,30 @@
  *
 */
 
-#ifndef LEVEL_DIALOG_H
-#define LEVEL_DIALOG_H
+#ifndef MAP_DIALOG_H
+#define MAP_DIALOG_H
 
 #include <QDialog>
-#include "level.h"
+#include "./map.h"
 class QLineEdit;
+class QComboBox;
 
 
-class LevelDialog : public QDialog
+class MapDialog : public QDialog
 {
 public:
-  LevelDialog(Level& _level);
-  ~LevelDialog();
+  MapDialog(Map& map);
+  ~MapDialog();
  
 private:
-  Level &level;
+  Map& _map;
 
-  QLineEdit *name_line_edit, *drawing_filename_line_edit;
-  QLineEdit *x_line_edit, *y_line_edit;
-  QPushButton *drawing_filename_button;
-  QPushButton *ok_button, *cancel_button;
-
-  void enable_dimensions(const bool enable);
+  QLineEdit *_building_name_line_edit;
+  QComboBox *_reference_floor_combo_box;
+  QPushButton *_ok_button, *_cancel_button;
 
 private slots:
-  void drawing_filename_button_clicked();
   void ok_button_clicked();
-  void drawing_filename_line_edited(const QString& text);
 };
 
 #endif

--- a/traffic_editor/gui/map_view.cpp
+++ b/traffic_editor/gui/map_view.cpp
@@ -54,7 +54,7 @@ void MapView::mousePressEvent(QMouseEvent *e)
     is_panning = true;
     pan_start_x = e->x();
     pan_start_y = e->y();
-    setCursor(Qt::ClosedHandCursor);
+    // setCursor(Qt::ClosedHandCursor);
     e->accept();
     return;
   }

--- a/traffic_editor/gui/table_list.cpp
+++ b/traffic_editor/gui/table_list.cpp
@@ -18,29 +18,38 @@
 #include "table_list.h"
 #include <QtWidgets>
 
-TableList::TableList()
+TableList::TableList(const int num_cols)
 {
   const char *style =
       "QTableWidget { background-color: #e0e0e0; color: black; } "
+      "QHeaderView::section { color: white; } "
       "QLineEdit { background:white; } "
       "QCheckBox { padding-left: 5px; background:white; } "
       "QPushButton { margin: 5px; background-color: #c0c0c0; border: 1px solid black; } "
       "QPushButton:pressed { background-color: #808080; }";
   setStyleSheet(style);
-  setColumnCount(2);
+  setColumnCount(num_cols);
   setMinimumSize(400, 200);
+
+  verticalHeader()->setVisible(false);
+  verticalHeader()->setSectionResizeMode(
+      QHeaderView::ResizeToContents);
+
+  horizontalHeader()->setVisible(true);
+  horizontalHeader()->setDefaultAlignment(Qt::AlignLeft);
+  horizontalHeader()->setSectionResizeMode(
+      0, QHeaderView::Stretch);
+
+  for (int col = 1; col < num_cols; col++)
+    horizontalHeader()->setSectionResizeMode(
+        col,
+        QHeaderView::ResizeToContents);
+
+  setAutoFillBackground(true);
+
   setSizePolicy(
       QSizePolicy::Fixed,
       QSizePolicy::MinimumExpanding);
-  horizontalHeader()->setVisible(false);
-  verticalHeader()->setVisible(false);
-  horizontalHeader()->setSectionResizeMode(
-      0, QHeaderView::Stretch);
-  horizontalHeader()->setSectionResizeMode(
-      1, QHeaderView::ResizeToContents);
-  verticalHeader()->setSectionResizeMode(
-      QHeaderView::ResizeToContents);
-  setAutoFillBackground(true);
 }
 
 TableList::~TableList()


### PR DESCRIPTION
 * top-level "map dialog" box to specify which level is the "reference level" that defines the coordinate frame
 * explicit scale measurements are now only necessary on the reference level
 * fiducial annotations now automatically set translation and scale relative to the reference level
 * fix regression in selection of edges (walls, doors, etc.)