### PR TITLE
Port ign changes

### DIFF
--- a/building_map_tools/building_map/doors/door.py
+++ b/building_map_tools/building_map/doors/door.py
@@ -73,6 +73,8 @@ class Door:
         lower_ele.text = str(bounds[0])
         upper_ele = SubElement(limit_ele, 'upper')
         upper_ele.text = str(bounds[1])
+        effort_ele = SubElement(limit_ele, 'effort')
+        effort_ele.text = str(500.0)
 
     '''Generate a single swing section/panel of a door.
 

--- a/building_map_tools/building_map/floor.py
+++ b/building_map_tools/building_map/floor.py
@@ -21,38 +21,6 @@ class Floor:
     def __repr__(self):
         return self.__str__()
 
-    def generate_geometry(self, parent_ele):
-        pose_ele = SubElement(parent_ele, 'pose')
-        pose_ele.text = f'0 0 {-self.thickness} 0 0 0'
-
-        geometry_ele = SubElement(parent_ele, 'geometry')
-
-        polyline_ele = SubElement(geometry_ele, 'polyline')
-
-        height_ele = SubElement(polyline_ele, 'height')
-        height_ele.text = f'{self.thickness}'
-
-        x_bounds = [1e9, -1e9]
-        y_bounds = [1e9, -1e9]
-        for vertex in self.vertices:
-            if vertex[0] < x_bounds[0]:
-                x_bounds[0] = vertex[0]
-            if vertex[0] > x_bounds[1]:
-                x_bounds[1] = vertex[0]
-
-            if vertex[1] < y_bounds[0]:
-                y_bounds[0] = vertex[1]
-            if vertex[1] > y_bounds[1]:
-                y_bounds[1] = vertex[1]
-
-            point_ele = SubElement(polyline_ele, 'point')
-            point_ele.text = f'{vertex[0]} {vertex[1]}'
-
-        cx = (x_bounds[0] + x_bounds[1]) / 2.0
-        cy = (y_bounds[0] + y_bounds[1]) / 2.0
-        dx = x_bounds[1] - x_bounds[0]
-        dy = y_bounds[1] - y_bounds[0]
-
     def find_vertex_idx(self, x, y):
         for v_idx, v in enumerate(self.vertices):
             dx = x - v[0]

--- a/building_map_tools/building_map/floor.py
+++ b/building_map_tools/building_map/floor.py
@@ -96,13 +96,17 @@ class Floor:
 
         collision_ele = SubElement(link_ele, 'collision')
         collision_ele.set('name', 'collision')
+        # Use the mesh as a collision element
+        collision_geometry_ele = SubElement(collision_ele, 'geometry')
+        collision_mesh_ele = SubElement(collision_geometry_ele, 'mesh')
+        collision_mesh_uri_ele = SubElement(collision_mesh_ele, 'uri')
+        collision_mesh_uri_ele.text = f'model://{model_name}/{obj_model_rel_path}'
+
 
         surface_ele = SubElement(collision_ele, 'surface')
         contact_ele = SubElement(surface_ele, 'contact')
         collide_bitmask_ele = SubElement(contact_ele, 'collide_bitmask')
         collide_bitmask_ele.text = '0x01'
-
-        self.generate_geometry(collision_ele)
 
         triangles = tripy.earclip(self.vertices)
 


### PR DESCRIPTION
Currently there is a bit of a feature difference between ignition and gazebo, so this is some minor changes backported from the ignition development branch to make implementation of a traffic editor that works for both easier, specifically:

- Add effort limit to door joints. If I understand correctly this is currently ignored in gazebo but works in ignition.
- Use the obj as a floor collision mesh. We were using obj for mesh and a polyline for collision before but polyline is not implemented in ignition yet. This change makes the obj used for both visual and collisions.

It would be nice to also start from a template and modify it since ignition requires a fair bit of common tags in the sdf to configure the gui and it gets very verbose to do it in Python (i.e. check [here](https://github.com/osrf/traffic_editor/blob/ign/building_map_tools/building_map/templates/ign_world.sdf) ) but this is a bit more involved and will be done in another PR.