### PR TITLE
Floor holes

### DIFF
--- a/building_map_tools/building_map/floor.py
+++ b/building_map_tools/building_map/floor.py
@@ -133,7 +133,8 @@ class Floor:
         model_name,
         model_path,
         vertices,
-        scale
+        scale,
+        holes
     ):
         print(f'generating floor polygon {floor_cnt} on floor {model_name}')
 
@@ -145,7 +146,16 @@ class Floor:
                 shapely.geometry.Point(v.x * scale, v.y * scale))
             vert_list.append((v.x * scale, v.y * scale))
 
-        self.polygon = shapely.geometry.Polygon(vert_list)
+        hole_vert_lists = []
+        for hole in holes:
+            hole_vertices = []
+            for v_idx in hole.vertex_indices:
+                v = vertices[v_idx]
+                hole_vertices.append((v.x * scale, v.y * scale))
+            hole_vert_lists.append(hole_vertices)
+        print(f'hole vertices: {hole_vert_lists}')
+
+        self.polygon = shapely.geometry.Polygon(vert_list, hole_vert_lists)
 
         link_ele = SubElement(model_ele, 'link')
         link_ele.set('name', f'floor_{floor_cnt}')
@@ -194,6 +204,9 @@ class Floor:
             if triangulation_debugging:
                 plt.subplot(1, 2, 1)
                 plt.plot(x, y, linewidth=5.0)
+                for hole in self.polygon.interiors:
+                    hx, hy = hole.coords.xy
+                    plt.plot(hx, hy, linewidth=3.0)
                 plt.axis('equal')
                 plt.subplot(1, 2, 2)
                 plt.plot(x, y, linewidth=5.0)

--- a/building_map_tools/building_map/hole.py
+++ b/building_map_tools/building_map/hole.py
@@ -1,0 +1,25 @@
+import math
+import os
+import shutil
+
+from xml.etree.ElementTree import SubElement
+
+from .param_value import ParamValue
+
+
+class Hole:
+    def __init__(self, yaml_node):
+        self.vertex_indices = []
+        for v_idx in yaml_node['vertices']:
+            self.vertex_indices.append(v_idx)
+
+        self.params = {}
+        if 'parameters' in yaml_node and yaml_node['parameters']:
+            for param_name, param_yaml in yaml_node['parameters'].items():
+                self.params[param_name] = ParamValue(param_yaml)
+
+    def __str__(self):
+        return f'hole ({len(self.vertex_indices)} vertices)'
+
+    def __repr__(self):
+        return self.__str__()

--- a/building_map_tools/building_map/level.py
+++ b/building_map_tools/building_map/level.py
@@ -592,6 +592,6 @@ class Level:
         return (
             f'{-self.translation[0]} '
             f'{-self.translation[1]} '
-            f'{self.elevation * 0.26} '
+            f'{self.elevation} '
             '0 0 0'
         )

--- a/building_map_tools/building_map/level.py
+++ b/building_map_tools/building_map/level.py
@@ -11,6 +11,7 @@ from ament_index_python.packages import get_package_share_directory
 from .edge import Edge
 from .fiducial import Fiducial
 from .floor import Floor
+from .hole import Hole
 from .model import Model
 from .vertex import Vertex
 from .doors.double_sliding_door import DoubleSlidingDoor
@@ -77,6 +78,11 @@ class Level:
         if 'floors' in yaml_node:
             for floor_yaml in yaml_node['floors']:
                 self.floors.append(Floor(floor_yaml))
+
+        self.holes = []
+        if 'holes' in yaml_node:
+            for hole_yaml in yaml_node['holes']:
+                self.holes.append(Hole(hole_yaml))
 
     def calculate_scale_using_measurements(self):
         # use the measurements to estimate scale for this level
@@ -381,7 +387,8 @@ class Level:
                 model_name,
                 model_path,
                 self.vertices,
-                self.scale)
+                self.scale,
+                self.holes)
 
     def write_sdf(self, model_name, model_path):
         sdf_ele = Element('sdf', {'version': '1.6'})
@@ -585,6 +592,6 @@ class Level:
         return (
             f'{-self.translation[0]} '
             f'{-self.translation[1]} '
-            f'{self.elevation} '
+            f'{self.elevation * 0.26} '
             '0 0 0'
         )

--- a/building_map_tools/building_map/model.py
+++ b/building_map_tools/building_map/model.py
@@ -12,7 +12,7 @@ class Model:
             self.z = yaml_node['z']
         else:
             print('parsed a deprecated .building.yaml, model should have a z'
-                    ' field, setting elevation to 0.0 for now')
+                  ' field, setting elevation to 0.0 for now')
         self.yaw = yaml_node['yaw']
 
     def generate(self, world_ele, model_cnt, scale):

--- a/traffic_editor/gui/building_level.h
+++ b/traffic_editor/gui/building_level.h
@@ -78,6 +78,12 @@ private:
   void draw_fiducials(QGraphicsScene *scene) const;
   void draw_polygons(QGraphicsScene *scene) const;
 
+  // helper function
+  void draw_polygon(
+      QGraphicsScene *scene,
+      const QBrush& brush,
+      const Polygon& polygon) const;
+
   void add_door_swing_path(
       QPainterPath &path,
       double hinge_x,

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -311,12 +311,16 @@ Editor::Editor()
   create_tool_button(TOOL_ADD_VERTEX, ":icons/vertex.svg", "Add Vertex (V)");
   create_tool_button(TOOL_ADD_FIDUCIAL, ":icons/fiducial.svg", "Add Fiducial");
   create_tool_button(TOOL_ADD_LANE, "", "Add Lane (L)");
-  create_tool_button(TOOL_ADD_WALL, "", "Add Wall (W)");
-  create_tool_button(TOOL_ADD_MEAS, "", "Add Measurement");
-  create_tool_button(TOOL_ADD_DOOR, "", "Add Door");
+  create_tool_button(TOOL_ADD_WALL, ":icons/wall.svg", "Add Wall (W)");
+  create_tool_button(
+      TOOL_ADD_MEAS,
+      ":icons/measurement.svg",
+      "Add Measurement");
+  create_tool_button(TOOL_ADD_DOOR, ":icons/door.svg", "Add Door");
   create_tool_button(TOOL_ADD_MODEL, "", "Add Model");
-  create_tool_button(TOOL_ADD_FLOOR, "", "Add Floor Polygon");
-  create_tool_button(TOOL_ADD_ROI, ":icons/roi.svg", "Add Region of Interest");
+  create_tool_button(TOOL_ADD_FLOOR, ":icons/floor.svg", "Add floor polygon");
+  create_tool_button(TOOL_ADD_HOLE, ":icons/hole.svg", "Add hole polygon");
+  create_tool_button(TOOL_ADD_ROI, ":icons/roi.svg", "Add region of interest");
   create_tool_button(TOOL_EDIT_POLYGON, "", "Edit Polygon");
 
   connect(
@@ -1995,6 +1999,7 @@ void Editor::set_mode(const EditorModeId _mode, const QString& mode_string)
   set_tool_visibility(TOOL_ADD_DOOR, mode == MODE_BUILDING);
   set_tool_visibility(TOOL_ADD_MODEL, mode == MODE_BUILDING);
   set_tool_visibility(TOOL_ADD_FLOOR, mode == MODE_BUILDING);
+  set_tool_visibility(TOOL_ADD_HOLE, mode == MODE_BUILDING);
   set_tool_visibility(TOOL_ADD_FIDUCIAL, mode == MODE_BUILDING);
 
   // traffic tools

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -525,11 +525,11 @@ void Editor::project_new()
   QFileInfo file_info(dialog.selectedFiles().first());
   std::string fn = file_info.fileName().toStdString();
 
+  project.clear();
   project.filename = file_info.absoluteFilePath().toStdString();
   QString dir_path = file_info.dir().path();
   QDir::setCurrent(dir_path);
 
-  project.building.clear();
   create_scene();
   project_save();
   level_table->update(project.building);

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -637,6 +637,7 @@ void Editor::mouse_event(const MouseType t, QMouseEvent *e)
     case TOOL_ADD_MODEL:    mouse_add_model(t, e, p); break;
     case TOOL_ROTATE:       mouse_rotate(t, e, p); break;
     case TOOL_ADD_FLOOR:    mouse_add_floor(t, e, p); break;
+    case TOOL_ADD_HOLE:     mouse_add_hole(t, e, p); break;
     case TOOL_EDIT_POLYGON: mouse_edit_polygon(t, e, p); break;
     case TOOL_ADD_FIDUCIAL: mouse_add_fiducial(t, e, p); break;
     case TOOL_ADD_ROI:      mouse_add_roi(t, e, p); break;
@@ -765,6 +766,7 @@ const QString Editor::tool_id_to_string(const int id)
     case TOOL_ADD_DOOR: return "add door";
     case TOOL_ADD_MODEL: return "add m&odel";
     case TOOL_ADD_FLOOR: return "add &floor";
+    case TOOL_ADD_HOLE: return "add hole";
     case TOOL_EDIT_POLYGON: return "&edit polygon";
     default: return "unknown tool ID";
   }
@@ -1800,6 +1802,12 @@ void Editor::mouse_add_floor(
     const MouseType t, QMouseEvent *e, const QPointF &p)
 {
   mouse_add_polygon(t, e, p, Polygon::FLOOR);
+}
+
+void Editor::mouse_add_hole(
+    const MouseType t, QMouseEvent *e, const QPointF &p)
+{
+  mouse_add_polygon(t, e, p, Polygon::HOLE);
 }
 
 void Editor::mouse_add_roi(

--- a/traffic_editor/gui/editor.h
+++ b/traffic_editor/gui/editor.h
@@ -106,7 +106,8 @@ private:
     TOOL_EDIT_POLYGON,
     TOOL_ADD_ZONE,
     TOOL_ADD_FIDUCIAL,
-    TOOL_ADD_ROI
+    TOOL_ADD_ROI,
+    TOOL_ADD_HOLE,
   } tool_id = TOOL_SELECT;
 
   std::map<ToolId, QAction *> tools;

--- a/traffic_editor/gui/editor.h
+++ b/traffic_editor/gui/editor.h
@@ -277,6 +277,7 @@ private:
   void mouse_add_door(const MouseType t, QMouseEvent *e, const QPointF &p);
   void mouse_add_model(const MouseType t, QMouseEvent *e, const QPointF &p);
   void mouse_add_floor(const MouseType t, QMouseEvent *e, const QPointF &p);
+  void mouse_add_hole(const MouseType t, QMouseEvent *e, const QPointF &p);
   void mouse_add_roi(const MouseType t, QMouseEvent *e, const QPointF &p);
   void mouse_edit_polygon(const MouseType t, QMouseEvent *e, const QPointF &p);
 

--- a/traffic_editor/gui/polygon.h
+++ b/traffic_editor/gui/polygon.h
@@ -40,7 +40,8 @@ public:
     UNDEFINED = 0,
     FLOOR,
     ZONE,
-    ROI
+    ROI,
+    HOLE
   } type = UNDEFINED;
 
   Polygon();

--- a/traffic_editor/gui/project.cpp
+++ b/traffic_editor/gui/project.cpp
@@ -25,6 +25,7 @@
 #include <QGraphicsItem>
 
 using std::string;
+using std::vector;
 
 
 Project::Project()
@@ -491,7 +492,8 @@ void Project::set_selected_containing_polygon(
     return;
 
   // holes are "higher" in our Z-stack (to make them clickable), so first
-  // we need to search for holes. Then we can search for non-holes
+  // we need to make a list of all polygons that contain this point.
+  vector<Polygon *> containing_polygons;
   for (size_t i = 0; i < level->polygons.size(); i++)
   {
     Polygon& polygon = level->polygons[i];
@@ -503,10 +505,22 @@ void Project::set_selected_containing_polygon(
     }
     QPolygonF qpolygon(polygon_vertices);
     if (qpolygon.containsPoint(QPoint(x, y), Qt::OddEvenFill))
+      containing_polygons.push_back(&level->polygons[i]);
+  }
+
+  // first search for holes
+  for (Polygon* p : containing_polygons)
+    if (p->type == Polygon::HOLE)
     {
-      polygon.selected = true;
+      p->selected = true;
       return;
     }
+
+  // if we get here, just return the first thing.
+  for (Polygon* p : containing_polygons)
+  {
+    p->selected = true;
+    return;
   }
 }
 

--- a/traffic_editor/gui/project.cpp
+++ b/traffic_editor/gui/project.cpp
@@ -509,3 +509,12 @@ void Project::set_selected_containing_polygon(
     }
   }
 }
+
+void Project::clear()
+{
+  building.clear();
+  name.clear();
+  filename.clear();
+  scenarios.clear();
+  scenario_idx = -1;
+}

--- a/traffic_editor/gui/project.cpp
+++ b/traffic_editor/gui/project.cpp
@@ -490,6 +490,8 @@ void Project::set_selected_containing_polygon(
   if (level == nullptr)
     return;
 
+  // holes are "higher" in our Z-stack (to make them clickable), so first
+  // we need to search for holes. Then we can search for non-holes
   for (size_t i = 0; i < level->polygons.size(); i++)
   {
     Polygon& polygon = level->polygons[i];

--- a/traffic_editor/gui/project.h
+++ b/traffic_editor/gui/project.h
@@ -50,6 +50,8 @@ public:
   bool save();
   bool load(const std::string& _filename);
 
+  void clear();
+
   void add_scenario_vertex(int level_index, double x, double y);
   void scenario_row_clicked(const int row);
   void draw(

--- a/traffic_editor/resources/icons/door.svg
+++ b/traffic_editor/resources/icons/door.svg
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 16.933334 16.933334"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="door.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.2"
+     inkscape:cx="27.100113"
+     inkscape:cy="33.864481"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1027"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-280.06665)">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 4.6274451,295.74794 v -14.31585 h 8.1812699 l 0.01885,14.29223 z"
+       id="path815"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <circle
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path817"
+       cx="11.528274"
+       cy="289.65305"
+       r="0.49609375" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.29922625;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect821"
+       width="5.7535338"
+       height="5.1629467"
+       x="5.8284969"
+       y="282.58313" />
+  </g>
+</svg>

--- a/traffic_editor/resources/icons/floor.svg
+++ b/traffic_editor/resources/icons/floor.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 16.933334 16.933334"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="floor.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.2"
+     inkscape:cx="23.307062"
+     inkscape:cy="26.535094"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1027"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-280.06665)">
+    <path
+       style="fill:#9d9d9d;fill-opacity:1;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 1.8544457,294.89749 v -7.21698 h 7.1815476 v -6.07124 h 6.4610307 v 10.97312 z"
+       id="path3718"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+  </g>
+</svg>

--- a/traffic_editor/resources/icons/hole.svg
+++ b/traffic_editor/resources/icons/hole.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 16.933334 16.933334"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="floor_hole.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.919596"
+     inkscape:cx="12.655125"
+     inkscape:cy="20.619827"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1027"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-280.06665)">
+    <path
+       style="fill:#9d9d9d;fill-opacity:1;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 1.8544457,294.89749 v -7.21698 h 7.1815476 v -6.07124 h 6.4610307 v 10.97312 z"
+       id="path3718"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="fill:#ffffff;stroke:#000000;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       d="m 7.7248884,290.62163 5.1026786,-4.08686 0.377976,5.31529 z"
+       id="path831"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/traffic_editor/resources/icons/measurement.svg
+++ b/traffic_editor/resources/icons/measurement.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 16.933334 16.933334"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="measurement.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.2"
+     inkscape:cx="6.6106333"
+     inkscape:cy="32.695808"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1027"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-280.06665)">
+    <path
+       style="fill:none;stroke:#f758ea;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 2.3151041,291.75557 14.882812,284.19604"
+       id="path833"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <circle
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.265;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path816"
+       cx="2.3032923"
+       cy="291.67288"
+       r="1.7634745" />
+    <circle
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path816-3"
+       cx="14.811942"
+       cy="284.1488"
+       r="1.7634746" />
+  </g>
+</svg>

--- a/traffic_editor/resources/icons/wall.svg
+++ b/traffic_editor/resources/icons/wall.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 16.933334 16.933334"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="wall.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.2"
+     inkscape:cx="23.574919"
+     inkscape:cy="33.052951"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1027"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-280.06665)">
+    <path
+       style="fill:none;stroke:#1812f4;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 2.3151041,291.75557 14.882812,284.19604"
+       id="path833"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <circle
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.265;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path816"
+       cx="2.3032923"
+       cy="291.67288"
+       r="1.7634745" />
+    <circle
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.26499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path816-3"
+       cx="14.811942"
+       cy="284.1488"
+       r="1.7634746" />
+  </g>
+</svg>

--- a/traffic_editor/resources/resource.qrc
+++ b/traffic_editor/resources/resource.qrc
@@ -7,5 +7,10 @@
   <file>icons/select.svg</file>
   <file>icons/fiducial.svg</file>
   <file>icons/roi.svg</file>
+  <file>icons/floor.svg</file>
+  <file>icons/hole.svg</file>
+  <file>icons/wall.svg</file>
+  <file>icons/door.svg</file>
+  <file>icons/measurement.svg</file>
 </qresource>
 </RCC>


### PR DESCRIPTION
 * add a GUI tool to draw "hole" polygons on top of floors to annotate multi-level atriums
 * incorporate holes into floor triangulations in `building_map_tools` when generating Gazebo worlds
 * add a few more toolbar icons