### PR TITLE
XY translation of each level in a 'flattened' world generation mode

### DIFF
--- a/building_map_tools/building_map/building.py
+++ b/building_map_tools/building_map/building.py
@@ -114,7 +114,7 @@ class Building:
                 nav_graphs[f'{i}'] = g
         return nav_graphs
 
-    def generate_sdf_world(self):
+    def generate_sdf_world(self, flattened):
         """ Return an etree of this Building in SDF XML """
 
         sdf = Element('sdf', {'version': '1.6'})
@@ -153,7 +153,7 @@ class Building:
             uri_ele = SubElement(level_include_ele, 'uri')
             uri_ele.text = f'model://{level_model_name}'
             pose_ele = SubElement(level_include_ele, 'pose')
-            pose_ele.text = level.pose_string()
+            pose_ele.text = level.pose_string(flattened)
 
         return sdf
 

--- a/building_map_tools/building_map/generator.py
+++ b/building_map_tools/building_map/generator.py
@@ -17,7 +17,13 @@ class Generator:
             y = yaml.safe_load(f)
             return Building(y)
 
-    def generate_sdf(self, input_filename, output_filename, output_models_dir):
+    def generate_sdf(
+        self,
+        input_filename,
+        output_filename,
+        output_models_dir,
+        options
+    ):
         print('generating {} from {}'.format(output_filename, input_filename))
 
         building = self.parse_editor_yaml(input_filename)
@@ -28,7 +34,10 @@ class Generator:
         building.generate_sdf_models(output_models_dir)
 
         # generate a top-level SDF for convenience
-        sdf = building.generate_sdf_world()
+        flattened = 'flattened' in options
+        print(f'generator options: {options} flattened = {flattened}')
+
+        sdf = building.generate_sdf_world(flattened)
 
         indent_etree(sdf)
         sdf_str = str(ElementToString(sdf), 'utf-8')

--- a/building_map_tools/building_map/level.py
+++ b/building_map_tools/building_map/level.py
@@ -30,6 +30,16 @@ class Level:
         if 'elevation' in yaml_node:
             self.elevation = yaml_node['elevation']
 
+        if 'flattened_x_offset' in yaml_node:
+            self.flattened_x_offset = yaml_node['flattened_x_offset']
+        else:
+            self.flattened_x_offset = 0.0
+
+        if 'flattened_y_offset' in yaml_node:
+            self.flattened_y_offset = yaml_node['flattened_y_offset']
+        else:
+            self.flattened_y_offset = 0.0
+
         self.fiducials = []
         if 'fiducials' in yaml_node:
             for fiducial_yaml in yaml_node['fiducials']:
@@ -588,10 +598,17 @@ class Level:
         bounds = self.floors[0].polygon.bounds
         return ((bounds[0] + bounds[2]) / 2.0, (bounds[1] + bounds[3]) / 2.0)
 
-    def pose_string(self):
-        return (
-            f'{-self.translation[0]} '
-            f'{-self.translation[1]} '
-            f'{self.elevation} '
-            '0 0 0'
-        )
+    def pose_string(self, flattened):
+        if flattened:
+            return (
+                f'{-self.translation[0] + self.flattened_x_offset} '
+                f'{-self.translation[1] + self.flattened_y_offset} '
+                f'0 0 0 0'
+            )
+        else:
+            return (
+                f'{-self.translation[0]} '
+                f'{-self.translation[1]} '
+                f'{self.elevation} '
+                '0 0 0'
+            )

--- a/building_map_tools/building_map_generators/building_map_gazebo.py
+++ b/building_map_tools/building_map_generators/building_map_gazebo.py
@@ -3,11 +3,14 @@ from building_map.generator import Generator
 
 
 def main():
-    if len(sys.argv) != 4:
-        print('usage: building_map_gazebo INPUT OUTPUT_WORLD OUTPUT_MODEL_DIR')
+    # todo: be all fancy and use argparse
+    if len(sys.argv) < 4:
+        print('usage: building_map_gazebo INPUT OUTPUT_WORLD '
+              'OUTPUT_MODEL_DIR [OPTIONS]')
         sys.exit(1)
     input_filename = sys.argv[1]
     output_filename = sys.argv[2]
     output_model_dir = sys.argv[3]
+    options = sys.argv[4:]
     g = Generator()
-    g.generate_sdf(input_filename, output_filename, output_model_dir)
+    g.generate_sdf(input_filename, output_filename, output_model_dir, options)

--- a/traffic_editor/gui/building_level.cpp
+++ b/traffic_editor/gui/building_level.cpp
@@ -86,6 +86,11 @@ bool BuildingLevel::from_yaml(
     }
   }
 
+  if (_data["flattened_x_offset"])
+    flattened_x_offset = _data["flattened_x_offset"].as<double>();
+  if (_data["flattened_y_offset"])
+    flattened_y_offset = _data["flattened_y_offset"].as<double>();
+
   load_yaml_edge_sequence(_data, "lanes", Edge::LANE);
   load_yaml_edge_sequence(_data, "walls", Edge::WALL);
   load_yaml_edge_sequence(_data, "measurements", Edge::MEAS);
@@ -185,6 +190,8 @@ YAML::Node BuildingLevel::to_yaml() const
     y["y_meters"] = y_meters;
   }
   y["elevation"] = elevation;
+  y["flattened_x_offset"] = flattened_x_offset;
+  y["flattened_y_offset"] = flattened_y_offset;
 
   for (const auto &v : vertices)
     y["vertices"].push_back(v.to_yaml());

--- a/traffic_editor/gui/building_level.h
+++ b/traffic_editor/gui/building_level.h
@@ -51,6 +51,11 @@ public:
   double x_meters = 10.0;  // manually specified if no drawing supplied
   double y_meters = 10.0;  // manually specified if no drawing supplied
 
+  // when generating the building in "flattened" mode, the levels have
+  // to be offset in the (x, y) plane to avoid clobbering each other.
+  double flattened_x_offset = 0.0;
+  double flattened_y_offset = 0.0;
+
   std::vector<Model> models;
   std::vector<Fiducial> fiducials;
 

--- a/traffic_editor/gui/building_level_dialog.cpp
+++ b/traffic_editor/gui/building_level_dialog.cpp
@@ -71,6 +71,20 @@ BuildingLevelDialog::BuildingLevelDialog(BuildingLevel& _level)
   y_hbox->addWidget(new QLabel("y dimension (meters):"));
   y_hbox->addWidget(y_line_edit);
 
+  flattened_x_offset_line_edit =
+      new QLineEdit(QString::number(building_level.flattened_x_offset));
+  QHBoxLayout *flattened_x_offset_hbox = new QHBoxLayout;
+  flattened_x_offset_hbox->addWidget(
+      new QLabel("flattened x offset (meters)"));
+  flattened_x_offset_hbox->addWidget(flattened_x_offset_line_edit);
+
+  flattened_y_offset_line_edit =
+      new QLineEdit(QString::number(building_level.flattened_y_offset));
+  QHBoxLayout *flattened_y_offset_hbox = new QHBoxLayout;
+  flattened_y_offset_hbox->addWidget(
+      new QLabel("flattened y offset (meters)"));
+  flattened_y_offset_hbox->addWidget(flattened_y_offset_line_edit);
+
   QHBoxLayout *bottom_buttons_hbox = new QHBoxLayout;
   bottom_buttons_hbox->addWidget(cancel_button);
   bottom_buttons_hbox->addWidget(ok_button);
@@ -92,6 +106,8 @@ BuildingLevelDialog::BuildingLevelDialog(BuildingLevel& _level)
   top_vbox->addLayout(instr_hbox);
   top_vbox->addLayout(x_hbox);
   top_vbox->addLayout(y_hbox);
+  top_vbox->addLayout(flattened_x_offset_hbox);
+  top_vbox->addLayout(flattened_y_offset_hbox);
   // todo: some sort of separator (?)
   top_vbox->addLayout(bottom_buttons_hbox);
 
@@ -177,6 +193,12 @@ void BuildingLevelDialog::ok_button_clicked()
     building_level.x_meters = 0.0;
     building_level.y_meters = 0.0;
   }
+
+  building_level.flattened_x_offset =
+      flattened_x_offset_line_edit->text().toDouble();
+  building_level.flattened_y_offset =
+      flattened_y_offset_line_edit->text().toDouble();
+
   building_level.calculate_scale();
   accept();
 }

--- a/traffic_editor/gui/building_level_dialog.h
+++ b/traffic_editor/gui/building_level_dialog.h
@@ -34,6 +34,8 @@ private:
 
   QLineEdit *name_line_edit, *drawing_filename_line_edit;
   QLineEdit *x_line_edit, *y_line_edit;
+  QLineEdit *flattened_x_offset_line_edit;
+  QLineEdit *flattened_y_offset_line_edit;
   QLineEdit *elevation_line_edit;
   QPushButton *drawing_filename_button;
   QPushButton *ok_button, *cancel_button;


### PR DESCRIPTION
Optionally flatten buildings, arranging each level on a user-specified XY offset. This mode is accessed by specifying a `flattened` argument to the building map generator. By default it is not used and a "physically realistic" Z stack is generated using the fiducial annotations for inter-level XY alignment.
