### PR TITLE
fix wall collision bitmask and door scaling issues

### DIFF
--- a/building_map_tools/building_map/doors/double_sliding_door.py
+++ b/building_map_tools/building_map/doors/double_sliding_door.py
@@ -5,11 +5,8 @@ from .door import Door
 class DoubleSlidingDoor(Door):
     def __init__(self, door_edge):
         super().__init__(door_edge)
-        print(f'DoubleSliding({self.name})')
 
     def generate(self, world_ele, options):
-        print('DoubleSliding.generate()')
-
         self.generate_sliding_section(
             'left',
             self.length/2 - 0.01,

--- a/building_map_tools/building_map/doors/double_swing_door.py
+++ b/building_map_tools/building_map/doors/double_swing_door.py
@@ -5,11 +5,8 @@ from .door import Door
 class DoubleSwingDoor(Door):
     def __init__(self, door_edge):
         super().__init__(door_edge)
-        print(f'DoubleSwingDoor({self.name})')
 
     def generate(self, world_ele, options):
-        print('DoubleSwingDoor.generate()')
-
         self.generate_swing_section(
             'left',
             self.length / 2 - 0.01,

--- a/building_map_tools/building_map/edge.py
+++ b/building_map_tools/building_map/edge.py
@@ -3,7 +3,7 @@ from .param_value import ParamValue
 
 
 class Edge:
-    def __init__(self, yaml_node, vertices):
+    def __init__(self, yaml_node):
         self.start_idx = int(yaml_node[0])
         self.end_idx = int(yaml_node[1])
         self.params = {}
@@ -11,13 +11,11 @@ class Edge:
             for param_name, param_yaml in yaml_node[2].items():
                 self.params[param_name] = ParamValue(param_yaml)
 
-        self.calc_statistics(vertices)
-
-    def calc_statistics(self, vertices):
-        self.x1 = vertices[self.start_idx].x
-        self.y1 = vertices[self.start_idx].y
-        self.x2 = vertices[self.end_idx].x
-        self.y2 = vertices[self.end_idx].y
+    def calc_statistics(self, vertices, scale):
+        self.x1 = vertices[self.start_idx].x * scale
+        self.y1 = vertices[self.start_idx].y * scale
+        self.x2 = vertices[self.end_idx].x * scale
+        self.y2 = vertices[self.end_idx].y * scale
         self.dx = self.x1 - self.x2
         self.dy = self.y1 - self.y2
         self.length = math.sqrt(self.dx*self.dx + self.dy*self.dy)


### PR DESCRIPTION
 * door-edge scaling was broken due to change in how we are "deferring" to compute scale (required to use fiducials). This PR calculates the door scale at the proper time in the sequence.
 * restore collision bitmask to walls now that we're using polygonal mesh walls instead of box primitives as previously