### PR TITLE
Calculate floorplan drawing rotations

### DIFF
--- a/building_map_tools/building_map/building.py
+++ b/building_map_tools/building_map/building.py
@@ -35,9 +35,9 @@ class Building:
             s += f'{level_name}: ({len(level.vertices)} vertices) '
         return s
 
-    def transform_all_vertices():
+    def transform_all_vertices(self):
         """ Transform all vertices on all levels to a unified system """
-        for level_name, level in self.levels.items();
+        for level_name, level in self.levels.items():
             level.transform_all_vertices()
 
     def calculate_level_offsets_and_scales(self):
@@ -100,9 +100,9 @@ class Building:
             bearing_sum[0] += math.sin(d_theta)
             bearing_sum[1] += math.cos(d_theta)
             print(f'  {d_theta}')
-        mean_bearing_difference = math.atan2(bearing_sum[0], bearing_sum[1])
+        mean_bearing_difference = -math.atan2(bearing_sum[0], bearing_sum[1])
         print(f'  Circular mean: {mean_bearing_difference}')
-        level.rotation = mean_bearing_difference
+        level.transform.set_rotation(mean_bearing_difference)
 
         print("Distances:")
         print(distances)
@@ -112,7 +112,8 @@ class Building:
             mean_rel_scale += distance[1] / distance[0]
         mean_rel_scale /= float(len(distances))
         print(f'mean relative scale: {mean_rel_scale}')
-        level.scale = self.ref_level.scale / mean_rel_scale
+        ref_scale = self.ref_level.transform.scale
+        level.transform.set_scale(ref_scale / mean_rel_scale)
 
         mean_translation = [0.0, 0.0]
         cr = math.cos(mean_bearing_difference)
@@ -129,13 +130,13 @@ class Building:
             mean_translation[1] += rot_f1y - f_pair[0].y
 
         if len(fiducials):
-            mean_translation[0] *= self.ref_level.scale / float(len(fiducials))
-            mean_translation[1] *= self.ref_level.scale / float(len(fiducials))
+            mean_translation[0] *= -ref_scale / float(len(fiducials))
+            mean_translation[1] *= -ref_scale / float(len(fiducials))
         print(
             f'translation: '
             f'({mean_translation[0]:.5}, '
             f'{mean_translation[1]:.5})')
-        level.translation = mean_translation
+        level.transform.set_translation(*mean_translation)
 
     def generate_nav_graphs(self):
         """ Returns a dict of all non-empty nav graphs """
@@ -186,7 +187,7 @@ class Building:
             uri_ele = SubElement(level_include_ele, 'uri')
             uri_ele.text = f'model://{level_model_name}'
             pose_ele = SubElement(level_include_ele, 'pose')
-            pose_ele.text = f'0 0 {level.elevation} 0 0 0'
+            pose_ele.text = f'0 0 {level.elevation/4} 0 0 0'
 
         # add floor-toggle GUI plugin parameters
         if 'gazebo' in options:

--- a/building_map_tools/building_map/edge.py
+++ b/building_map_tools/building_map/edge.py
@@ -11,11 +11,11 @@ class Edge:
             for param_name, param_yaml in yaml_node[2].items():
                 self.params[param_name] = ParamValue(param_yaml)
 
-    def calc_statistics(self, vertices, scale):
-        self.x1 = vertices[self.start_idx].x * scale
-        self.y1 = vertices[self.start_idx].y * scale
-        self.x2 = vertices[self.end_idx].x * scale
-        self.y2 = vertices[self.end_idx].y * scale
+    def calc_statistics(self, vertices):
+        self.x1 = vertices[self.start_idx].x
+        self.y1 = vertices[self.start_idx].y
+        self.x2 = vertices[self.end_idx].x
+        self.y2 = vertices[self.end_idx].y
         self.dx = self.x1 - self.x2
         self.dy = self.y1 - self.y2
         self.length = math.sqrt(self.dx*self.dx + self.dy*self.dy)

--- a/building_map_tools/building_map/fiducial.py
+++ b/building_map_tools/building_map/fiducial.py
@@ -12,3 +12,15 @@ class Fiducial:
         dx = f.x - self.x
         dy = f.y - self.y
         return math.sqrt(dx*dx + dy*dy)
+
+    def bearing(self, f):
+        """
+        Calculate the bearing angle to another fiducial.
+
+        If the fiducial 'f' is directly east (+x) of the current fiducial,
+        This function will return 0. If 'f' is directly north (+y), this
+        function will return pi/2.
+        """
+        dx = f.x - self.x
+        dy = f.y - self.y
+        return math.atan2(dy, dx)

--- a/building_map_tools/building_map/floor.py
+++ b/building_map_tools/building_map/floor.py
@@ -132,8 +132,7 @@ class Floor:
         floor_cnt,
         model_name,
         model_path,
-        vertices,
-        scale,
+        transformed_vertices,
         holes
     ):
         print(f'generating floor polygon {floor_cnt} on floor {model_name}')
@@ -141,17 +140,16 @@ class Floor:
         vert_list = []
         self.vertices = []
         for v_idx in self.vertex_indices:
-            v = vertices[v_idx]
-            self.vertices.append(
-                shapely.geometry.Point(v.x * scale, v.y * scale))
-            vert_list.append((v.x * scale, v.y * scale))
+            vx, vy = transformed_vertices[v_idx].xy()
+            self.vertices.append(shapely.geometry.Point(vx, vy))
+            vert_list.append((vx, vy))
 
         hole_vert_lists = []
         for hole in holes:
             hole_vertices = []
             for v_idx in hole.vertex_indices:
-                v = vertices[v_idx]
-                hole_vertices.append((v.x * scale, v.y * scale))
+                vx, vy = transform_vertex(vertices[v_idx])
+                hole_vertices.append((vx, vy))
             hole_vert_lists.append(hole_vertices)
         print(f'hole vertices: {hole_vert_lists}')
 

--- a/building_map_tools/building_map/model.py
+++ b/building_map_tools/building_map/model.py
@@ -15,18 +15,17 @@ class Model:
                   ' field, setting elevation to 0.0 for now')
         self.yaw = yaml_node['yaw']
 
-    def generate(self, world_ele, model_cnt, transform_point):
+    def generate(self, world_ele, model_cnt, transform):
         include_ele = SubElement(world_ele, 'include')
         name_ele = SubElement(include_ele, 'name')
         name_ele.text = f'{self.model_name}_{model_cnt}'
         uri_ele = SubElement(include_ele, 'uri')
         uri_ele.text = f'model://{self.model_name}'
         pose_ele = SubElement(include_ele, 'pose')
-        x, y = transform_point((self.x, self.y))
-        # x = self.x * scale
-        # y = self.y * scale
+        x, y = transform.transform_point((self.x, self.y))
         z = self.z
-        pose_ele.text = f'{x} {y} {z} 0 0 {self.yaw + 1.5707}'
+        yaw = self.yaw + 1.5707 + transform.rotation
+        pose_ele.text = f'{x} {y} {z} 0 0 {yaw}'
 
         # hack... for now, everything other than robots is static (?)
         non_static_model_names = [

--- a/building_map_tools/building_map/model.py
+++ b/building_map_tools/building_map/model.py
@@ -15,15 +15,16 @@ class Model:
                   ' field, setting elevation to 0.0 for now')
         self.yaw = yaml_node['yaw']
 
-    def generate(self, world_ele, model_cnt, scale):
+    def generate(self, world_ele, model_cnt, transform_point):
         include_ele = SubElement(world_ele, 'include')
         name_ele = SubElement(include_ele, 'name')
         name_ele.text = f'{self.model_name}_{model_cnt}'
         uri_ele = SubElement(include_ele, 'uri')
         uri_ele.text = f'model://{self.model_name}'
         pose_ele = SubElement(include_ele, 'pose')
-        x = self.x * scale
-        y = self.y * scale
+        x, y = transform_point((self.x, self.y))
+        # x = self.x * scale
+        # y = self.y * scale
         z = self.z
         pose_ele.text = f'{x} {y} {z} 0 0 {self.yaw + 1.5707}'
 

--- a/building_map_tools/building_map/transform.py
+++ b/building_map_tools/building_map/transform.py
@@ -23,7 +23,7 @@ class Transform:
 
     def set_scale(self, scale):
         self.scale = scale
- 
+
     def transform_point(self, p):
         vec = np.array([[p[0]], [p[1]]])
         transformed = (self.rot_mat @ vec) * self.scale + self.t_vec

--- a/building_map_tools/building_map/transform.py
+++ b/building_map_tools/building_map/transform.py
@@ -1,0 +1,30 @@
+import math
+import numpy as np
+
+
+class Transform:
+    """This class represents an 2D rotation, scaling, and translation."""
+
+    def __init__(self):
+        self.set_rotation(0)
+        self.set_translation(0, 0)
+        self.set_scale(1)
+
+    def set_rotation(self, rotation):
+        """Calculate rotation matrix"""
+        self.rotation = rotation
+        cr = math.cos(self.rotation)
+        sr = math.sin(self.rotation)
+        self.rot_mat = np.array([[cr, -sr], [sr, cr]])
+
+    def set_translation(self, tx, ty):
+        self.translation = (tx, ty)
+        self.t_vec = np.array([[self.translation[0]], [self.translation[1]]])
+
+    def set_scale(self, scale):
+        self.scale = scale
+ 
+    def transform_point(self, p):
+        vec = np.array([[p[0]], [p[1]]])
+        transformed = (self.rot_mat @ vec) * self.scale + self.t_vec
+        return (np.asscalar(transformed[0]), np.asscalar(transformed[1]))

--- a/building_map_tools/building_map/vertex.py
+++ b/building_map_tools/building_map/vertex.py
@@ -12,3 +12,6 @@ class Vertex:
         if len(yaml_node) > 4 and len(yaml_node[4]) > 0:
             for param_name, param_yaml in yaml_node[4].items():
                 self.params[param_name] = ParamValue(param_yaml)
+
+    def xy(self):
+        return (self.x, self.y)


### PR DESCRIPTION
 * use fiducial annotations on multi-floor buildings to align in rotation as well as scale and translation
 * consolidate the 2D transform math in `building_map_tools` into its own Python class and apply the rotation/scale/translation only in a single place