### PR TITLE
Add dependency to python-shapely in package.xml

### DIFF
--- a/building_map_tools/package.xml
+++ b/building_map_tools/package.xml
@@ -12,6 +12,7 @@
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>building_map_msgs</exec_depend>
   <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>python-shapely</exec_depend>
 
   <export>
     <build_type>ament_python</build_type>


### PR DESCRIPTION
Add dependency to shapely so it can be installed through rosdep.

Sadly since rosdep is based on Python2 (hence installs the python2 version of the dependency) and we need the Python3 version it still doesn't quite work, but should be fine once the rosdep Python3 tool is used.