### PR TITLE
Fix server to latest changes in level transform

### DIFF
--- a/building_map_tools/building_map/transform.py
+++ b/building_map_tools/building_map/transform.py
@@ -6,9 +6,9 @@ class Transform:
     """This class represents an 2D rotation, scaling, and translation."""
 
     def __init__(self):
-        self.set_rotation(0)
-        self.set_translation(0, 0)
-        self.set_scale(1)
+        self.set_rotation(0.0)
+        self.set_translation(0.0, 0.0)
+        self.set_scale(1.0)
 
     def set_rotation(self, rotation):
         """Calculate rotation matrix"""

--- a/building_map_tools/building_map_server/building_map_server.py
+++ b/building_map_tools/building_map_server/building_map_server.py
@@ -78,10 +78,10 @@ class BuildingMapServer(Node):
             image = AffineImage()
             image_filename = level.drawing_name
             image.encoding = image_filename.split('.')[-1]
-            image.scale = level.scale
-            image.x_offset = 0.0
-            image.y_offset = 0.0
-            image.yaw = 0.0
+            image.scale = level.transform.scale
+            image.x_offset = level.transform.translation[0]
+            image.y_offset = level.transform.translation[1]
+            image.yaw = level.transform.rotation
 
             image_path = os.path.join(self.map_dir, image_filename)
 


### PR DESCRIPTION
The map server was crashing since it was referring to a no-longer-existing member variable of level (scale).
Now it fills the message with the transform fields, also changed the defaults to floats and added them to the message for the future.