### PR TITLE
Static parameter for models

### DIFF
--- a/building_map_tools/building_map/model.py
+++ b/building_map_tools/building_map/model.py
@@ -13,6 +13,21 @@ class Model:
         else:
             print('parsed a deprecated .building.yaml, model should have a z'
                   ' field, setting elevation to 0.0 for now')
+
+        # temporary hack: whitelist of robot models which must be non-static
+        non_static_model_names = [
+          'Sesto',
+          'MiR100',
+          'Magni'
+        ]
+        if self.model_name in non_static_model_names:
+            self.static = False
+        else:
+            if 'static' in yaml_node:
+                self.static = yaml_node['static']
+            else:
+                self.static = True
+
         self.yaw = yaml_node['yaw']
 
     def generate(self, world_ele, model_cnt, transform):
@@ -27,12 +42,5 @@ class Model:
         yaw = self.yaw + 1.5707 + transform.rotation
         pose_ele.text = f'{x} {y} {z} 0 0 {yaw}'
 
-        # hack... for now, everything other than robots is static (?)
-        non_static_model_names = [
-          'Sesto',
-          'MiR100',
-          'Magni'
-        ]
-        if self.name not in non_static_model_names:
-            static_ele = SubElement(include_ele, 'static')
-            static_ele.text = 'true'
+        static_ele = SubElement(include_ele, 'static')
+        static_ele.text = str(self.static)

--- a/traffic_editor/gui/building.cpp
+++ b/traffic_editor/gui/building.cpp
@@ -320,8 +320,15 @@ void Building::add_model(
 
   printf("Building::add_model(%d, %.1f, %.1f, %.1f, %.2f, %s)\n",
       level_idx, x, y, z, yaw, model_name.c_str());
-  levels[level_idx].models.push_back(
-      Model(x, y, z, yaw, model_name, model_name));
+  Model m;
+  m.x = x;
+  m.y = y;
+  m.z = z;
+  m.yaw = yaw;
+  m.model_name = model_name;
+  m.instance_name = model_name;  // todo: add unique numeric suffix?
+  m.is_static = true;
+  levels[level_idx].models.push_back(m);
 }
 
 void Building::set_model_yaw(

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -1173,7 +1173,7 @@ void Editor::populate_property_editor(const Model& model)
   printf("populate_property_editor(model)\n");
   property_editor->blockSignals(true);  // otherwise we get tons of callbacks
 
-  property_editor->setRowCount(3);
+  property_editor->setRowCount(4);
 
   property_editor_set_row(
       0,
@@ -1190,6 +1190,12 @@ void Editor::populate_property_editor(const Model& model)
       "elevation",
       model.z,
       3,
+      true);
+
+  property_editor_set_row(
+      3,
+      "static",
+      model.is_static ? QString("true") : QString("false"),
       true);
 
   property_editor->blockSignals(false);  // re-enable callbacks

--- a/traffic_editor/gui/model.h
+++ b/traffic_editor/gui/model.h
@@ -31,22 +31,16 @@
 class Model
 {
 public:
-  double x;
-  double y;
-  double z;
-  double yaw;
+  double x = 0.0;
+  double y = 0.0;
+  double z = 0.0;
+  double yaw = 0.0;
   std::string model_name;
   std::string instance_name;
-  bool selected;  // only for visualization, not saved to YAML
+  bool selected = false;  // only for visualization, not saved to YAML
+  bool is_static = true;
 
   Model();
-  Model(
-      const double _x,
-      const double _y,
-      const double _z,
-      const double _yaw,
-      const std::string &_model_name,
-      const std::string &_instance_name);
 
   YAML::Node to_yaml() const;
   void from_yaml(const YAML::Node &data);


### PR DESCRIPTION
 * add GUI parameter for `static` attribute of simulation models
 * use this attribute when generating SDF XML
 * add a bit of spaghetti to try to preserve the existing (implicit) behavior