### PR TITLE
branch on double swing door direction for sim generation

### DIFF
--- a/building_map_tools/building_map/doors/double_swing_door.py
+++ b/building_map_tools/building_map/doors/double_swing_door.py
@@ -5,22 +5,30 @@ from .door import Door
 class DoubleSwingDoor(Door):
     def __init__(self, door_edge):
         super().__init__(door_edge)
+        motion_degrees = door_edge.params['motion_degrees'].value
+        self.motion_radians = 3.14 * motion_degrees / 180.0
+        self.motion_direction = door_edge.params['motion_direction'].value
 
     def generate(self, world_ele, options):
+        if self.motion_direction > 0:
+            x_flip_sign = 1.0
+        else:
+            x_flip_sign = -1.0
+
         self.generate_swing_section(
             'right',
             self.length / 2 - 0.01,
-            -self.length / 4,
-            (0, 1.6),
-            (-self.length / 4, 0, 0),
+            x_flip_sign * -self.length / 4,
+            (0, self.motion_radians),
+            (x_flip_sign * -self.length / 4, 0, 0),
             options)
 
         self.generate_swing_section(
             'left',
             self.length / 2 - 0.01,
-            self.length / 4,
-            (-1.6, 0),
-            (self.length / 4, 0, 0),
+            x_flip_sign * self.length / 4,
+            (-self.motion_radians, 0),
+            (x_flip_sign * self.length / 4, 0, 0),
             options)
 
         plugin_ele = SubElement(self.model_ele, 'plugin')

--- a/test_maps/CMakeLists.txt
+++ b/test_maps/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(test_maps)
+
+find_package(ament_cmake REQUIRED)
+
+install(DIRECTORY
+  maps/
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()
+
+file(GLOB_RECURSE traffic_editor_paths "maps/*.building.yaml")
+
+foreach(path ${traffic_editor_paths})
+
+  # Get the output world name
+  string(REPLACE "." ";" list1 ${path})
+  list(GET list1 0 name)
+  string(REPLACE "/" ";" list2 ${name})
+  list(GET list2 -1 world_name)
+
+  set(map_path ${path})
+  set(output_world_name ${world_name})
+  set(output_dir ${CMAKE_CURRENT_BINARY_DIR}/maps/${output_world_name})
+  set(output_world_path ${output_dir}/${output_world_name}.world)
+  set(output_model_dir ${output_dir}/models)
+
+  # first, generate the world
+  add_custom_command(
+    OUTPUT ${output_world_path}
+    COMMAND ros2 run building_map_tools building_map_gazebo ${map_path} ${output_world_path} ${output_model_dir}
+    DEPENDS ${map_path}
+  )
+
+  add_custom_target(generate_${output_world_name} ALL
+    DEPENDS ${output_world_path}
+  )
+
+  install(
+    DIRECTORY ${output_dir}
+    DESTINATION share/${PROJECT_NAME}/maps
+  )
+
+endforeach()

--- a/test_maps/maps/door_madness/door_madness.building.yaml
+++ b/test_maps/maps/door_madness/door_madness.building.yaml
@@ -1,0 +1,49 @@
+levels:
+  L1:
+    doors:
+      - [10, 11, {motion_axis: [1, start], motion_degrees: [3, 90], motion_direction: [2, -1], name: [1, negative_motion], type: [1, double_hinged]}]
+      - [8, 9, {motion_axis: [1, start], motion_degrees: [3, 90], motion_direction: [2, 1], name: [1, positive_motion], type: [1, double_hinged]}]
+    elevation: 0
+    flattened_x_offset: 0
+    flattened_y_offset: 0
+    floors:
+      - parameters: {texture_name: [1, blue_linoleum], texture_rotation: [3, 0], texture_scale: [3, 1]}
+        vertices: [0, 3, 4, 7]
+    layers:
+      {}
+    measurements:
+      - [0, 7, {distance: [3, 4]}]
+    models:
+      - {model_name: VendingMachine, name: VendingMachine, static: true, x: 62.373, y: 73.121, yaw: -3.1416, z: 0}
+      - {model_name: VendingMachine, name: VendingMachine, static: true, x: 62.64, y: 112.802, yaw: -3.1416, z: 0}
+      - {model_name: VendingMachine, name: VendingMachine, static: true, x: 111.89, y: 72.617, yaw: -3.1416, z: 0}
+      - {model_name: VendingMachine, name: VendingMachine, static: true, x: 111.355, y: 108.893, yaw: -3.1416, z: 0}
+    vertices:
+      - [27.219, 60.337, 0, ""]
+      - [75.157, 60.87, 0, ""]
+      - [122.026, 60.739, 0, ""]
+      - [177.423, 60.604, 0, ""]
+      - [177.157, 124.787, 0, ""]
+      - [122.828, 124.787, 0, ""]
+      - [74.89, 125.585, 0, ""]
+      - [25.621, 126.118, 0, ""]
+      - [75.157, 107.742, 0, ""]
+      - [74.89, 77.116, 0, ""]
+      - [122.029, 73.92, 0, ""]
+      - [122.828, 104.813, 0, ""]
+    walls:
+      - [0, 1, {}]
+      - [1, 2, {}]
+      - [2, 3, {}]
+      - [7, 6, {}]
+      - [6, 5, {}]
+      - [5, 4, {}]
+      - [5, 11, {}]
+      - [6, 8, {}]
+      - [9, 1, {}]
+      - [10, 2, {}]
+    x_meters: 3.161074671053361
+    y_meters: 3.161074671053361
+lifts:
+  {}
+name: building

--- a/test_maps/maps/door_madness/door_madness.project.yaml
+++ b/test_maps/maps/door_madness/door_madness.project.yaml
@@ -1,0 +1,4 @@
+building:
+  filename: door_madness.building.yaml
+name: door_madness
+version: 1

--- a/test_maps/package.xml
+++ b/test_maps/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>test_maps</name>
+  <version>0.0.0</version>
+  <description>
+    Some test maps for traffic_editor and building_map_tools.
+  </description>
+  <maintainer email="morgan@openrobotics.org">Morgan Quigley</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>building_map_tools</buildtool_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -1428,7 +1428,11 @@ void Editor::mouse_move(
     Building::NearestItem ni =
         project.building.nearest_items(level_idx, p.x(), p.y());
 
-    if (ni.model_idx >= 0 && ni.model_dist < 50.0)
+    // todo: use QGraphics stuff to see if we clicked a model pixmap...
+    const double model_dist_thresh = 0.5 /
+        project.building.levels[level_idx].drawing_meters_per_pixel;
+
+    if (ni.model_idx >= 0 && ni.model_dist < model_dist_thresh)
     {
       // Now we need to find the pixmap item for this model.
       mouse_motion_model = get_closest_pixmap_item(

--- a/traffic_editor/gui/project.cpp
+++ b/traffic_editor/gui/project.cpp
@@ -332,7 +332,11 @@ void Project::mouse_select_press(
         building.levels[level_idx].vertex_radius /
         building.levels[level_idx].drawing_meters_per_pixel;
 
-    if (ni.model_idx >= 0 && ni.model_dist < 50.0)
+    // todo: use QGraphics stuff to see if we clicked a model pixmap...
+    const double model_dist_thresh = 0.5 /
+        building.levels[level_idx].drawing_meters_per_pixel;
+
+    if (ni.model_idx >= 0 && ni.model_dist < model_dist_thresh)
       building.levels[level_idx].models[ni.model_idx].selected = true;
     else if (ni.vertex_idx >= 0 && ni.vertex_dist < vertex_dist_thresh)
       building.levels[level_idx].vertices[ni.vertex_idx].selected = true;


### PR DESCRIPTION
 * branch depending on sign of `motion_direction` for double hinged doors when generating simulation model
 * use the `motion_degrees` parameter when generating double hinged doors
 * add a test map package that has a pair of double swing doors (one with positive motion direction, one with negative motion direction) that will crash into vending machines if they open the incorrect direction
 * fix an unrelated but annoying bug when trying to move models in the GUI when explicit scale or measurements were not provided