### PR TITLE
added fixed joint offset for swing doors

### DIFF
--- a/building_map_tools/building_map/doors/double_swing_door.py
+++ b/building_map_tools/building_map/doors/double_swing_door.py
@@ -8,6 +8,7 @@ class DoubleSwingDoor(Door):
         motion_degrees = door_edge.params['motion_degrees'].value
         self.motion_radians = 3.14 * motion_degrees / 180.0
         self.motion_direction = door_edge.params['motion_direction'].value
+        self.joint_offset = 3 * self.thickness
 
     def generate(self, world_ele, options):
         if self.motion_direction > 0:
@@ -20,7 +21,7 @@ class DoubleSwingDoor(Door):
             self.length / 2 - 0.01,
             x_flip_sign * -self.length / 4,
             (0, self.motion_radians),
-            (x_flip_sign * -self.length / 4, 0, 0),
+            (x_flip_sign * (-self.length/4 + self.joint_offset), 0, 0),
             options)
 
         self.generate_swing_section(
@@ -28,7 +29,7 @@ class DoubleSwingDoor(Door):
             self.length / 2 - 0.01,
             x_flip_sign * self.length / 4,
             (-self.motion_radians, 0),
-            (x_flip_sign * self.length / 4, 0, 0),
+            (x_flip_sign * (self.length/4 - self.joint_offset), 0, 0),
             options)
 
         plugin_ele = SubElement(self.model_ele, 'plugin')

--- a/building_map_tools/building_map/doors/swing_door.py
+++ b/building_map_tools/building_map/doors/swing_door.py
@@ -8,6 +8,7 @@ class SwingDoor(Door):
         motion_degrees = door_edge.params['motion_degrees'].value
         self.motion_radians = 3.14 * motion_degrees / 180.0
         self.motion_direction = door_edge.params['motion_direction'].value
+        self.joint_offset = 3 * self.thickness
 
     def generate(self, world_ele, options):
         plugin_ele = SubElement(self.model_ele, 'plugin')
@@ -34,7 +35,7 @@ class SwingDoor(Door):
                 self.length - 0.01,
                 0,
                 (-self.motion_radians, 0),
-                (self.length / 2, 0, 0),
+                ((self.length/2 - self.joint_offset), 0, 0),
                 options)
             door_ele.set('left_joint_name', 'left_joint')
             door_ele.set('right_joint_name', 'empty_joint')
@@ -44,7 +45,7 @@ class SwingDoor(Door):
                 self.length - 0.01,
                 0,
                 (0, self.motion_radians),
-                (self.length / 2, 0, 0),
+                ((self.length/2 - self.joint_offset), 0, 0),
                 options)
             door_ele.set('left_joint_name', 'empty_joint')
             door_ele.set('right_joint_name', 'right_joint')


### PR DESCRIPTION
* added fixed offset for swing door joints, shifting them slightly inwards to prevent visually clipping through walls when opening
* current fixed offset is 3 times the door's width

* one side-effect, the opening of the door will shrink slightly as a result, existing narrow doorway cases might have robots unable to pass through (so far none in `rmf_demos` have this edge case)
* another side-effect, the work space of the doors will be slightly smaller from what is drawn by `traffic_editor`, which should be fine

https://github.com/osrf/traffic_editor/issues/101