### PR TITLE
Level name populated in Slotcar RobotState msg

### DIFF
--- a/building_gazebo_plugins/CMakeLists.txt
+++ b/building_gazebo_plugins/CMakeLists.txt
@@ -32,6 +32,7 @@ find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(rmf_fleet_msgs REQUIRED)
 find_package(rmf_door_msgs REQUIRED)
+find_package(building_map_msgs REQUIRED)
 
 include(GNUInstallDirs)
 
@@ -53,6 +54,7 @@ target_link_libraries(slotcar
     ${gazebo_ros_LIBRARIES}
     ${geometry_msgs_LIBRARIES}
     ${tf2_ros_LIBRARIES}
+    ${building_map_msgs_LIBRARIES}
 )
 
 target_include_directories(slotcar
@@ -64,6 +66,7 @@ target_include_directories(slotcar
     ${std_msgs_INCLUDE_DIRS}
     ${rmf_fleet_msgs_INCLUDE_DIRS}
     ${tf2_ros_INCLUDE_DIRS}
+    ${building_map_msgs_INCLUDE_DIRS}
 )
 
 # These lines are taken out because of this issue: https://github.com/ament/ament_cmake/issues/158

--- a/building_gazebo_plugins/package.xml
+++ b/building_gazebo_plugins/package.xml
@@ -25,6 +25,7 @@
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
+  <depend>building_map_msgs</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/building_gazebo_plugins/src/slotcar.cpp
+++ b/building_gazebo_plugins/src/slotcar.cpp
@@ -624,7 +624,7 @@ void SlotcarPlugin::map_cb(const building_map_msgs::msg::BuildingMap::SharedPtr 
     {
       for (const auto& vertex : graph.vertices)
       {
-        if (std::abs(compute_disp(vertex) - 0.0) < 1.0)
+        if (compute_disp(vertex) < 1.0)
         {
           _current_level_name = level.name;
           RCLCPP_INFO(logger(), "Setting slotcar level name [%s]",

--- a/building_gazebo_plugins/src/slotcar.cpp
+++ b/building_gazebo_plugins/src/slotcar.cpp
@@ -16,6 +16,8 @@
 #include <rmf_fleet_msgs/msg/robot_state.hpp>
 #include <rclcpp/logger.hpp>
 
+#include <building_map_msgs/msg/building_map.hpp>
+
 #include "utils.hpp"
 
 using namespace building_gazebo_plugins;
@@ -29,6 +31,8 @@ public:
   void Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf) override;
   void path_request_cb(const rmf_fleet_msgs::msg::PathRequest::SharedPtr msg);
   void mode_request_cb(const rmf_fleet_msgs::msg::ModeRequest::SharedPtr msg);
+  void map_cb(const building_map_msgs::msg::BuildingMap::SharedPtr msg);
+
   void OnUpdate();
 
 private:
@@ -41,6 +45,8 @@ private:
   rclcpp::Subscription<rmf_fleet_msgs::msg::PathRequest>::SharedPtr traj_sub;
   rclcpp::Subscription<rmf_fleet_msgs::msg::ModeRequest>::SharedPtr mode_sub;
   rclcpp::Publisher<rmf_fleet_msgs::msg::RobotState>::SharedPtr robot_state_pub;
+  rclcpp::Subscription<building_map_msgs::msg::BuildingMap>::SharedPtr _building_map_sub;
+
   rmf_fleet_msgs::msg::RobotState robot_state_msg;
 
   std::array<gazebo::physics::JointPtr, 2> joints;
@@ -63,6 +69,7 @@ private:
   int update_count = 0;
   std::string name;
   std::string current_task_id;
+  std::string _current_level_name;
 
   // Vehicle dynamic constants
   // TODO(MXG): Consider fetching these values from model data
@@ -218,6 +225,15 @@ void SlotcarPlugin::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf)
   robot_state_pub = _ros_node->create_publisher<rmf_fleet_msgs::msg::RobotState>(
       "/robot_state", 10);
 
+  // Subscription to /map
+  auto qos_profile = rclcpp::QoS(10);
+  qos_profile.transient_local();
+  _building_map_sub =
+    _ros_node->create_subscription<building_map_msgs::msg::BuildingMap>(
+        "/map",
+        qos_profile,
+        std::bind(&SlotcarPlugin::map_cb, this, std::placeholders::_1));
+
   joints[0] = _model->GetJoint("joint_tire_left");
   if (!joints[0])
     RCLCPP_ERROR(logger(), "Could not find tire for [joint_tire_left]");
@@ -331,6 +347,7 @@ void SlotcarPlugin::OnUpdate()
     robot_state_msg.location.y = wp.Pos().Y();
     robot_state_msg.location.yaw = wp.Rot().Yaw();
     robot_state_msg.location.t = now;
+    robot_state_msg.location.level_name = _current_level_name;
 
     robot_state_msg.task_id = current_task_id;
     robot_state_msg.path = remaining_path;
@@ -341,6 +358,9 @@ void SlotcarPlugin::OnUpdate()
 
   if (traj.empty())
     return;
+
+  if (remaining_path.size() != 0)
+    _current_level_name = remaining_path[0].level_name;
 
   double x_target = 0.0;
   double yaw_target = 0.0;
@@ -564,6 +584,57 @@ void SlotcarPlugin::path_request_cb(const rmf_fleet_msgs::msg::PathRequest::Shar
 void SlotcarPlugin::mode_request_cb(const rmf_fleet_msgs::msg::ModeRequest::SharedPtr msg)
 {
   current_mode = msg->mode;
+}
+
+void SlotcarPlugin::map_cb(const building_map_msgs::msg::BuildingMap::SharedPtr msg)
+{
+  if (!_current_level_name.empty())
+    return;
+
+  if (!_model)
+  {
+    RCLCPP_ERROR(logger(), "Received map before model was initialized");
+    return;
+  }
+
+  if (msg->levels.empty())
+  {
+    RCLCPP_ERROR(logger(), "Received empty building map");
+    return;
+  }
+
+  RCLCPP_INFO(logger(), "Received building map with %d levels", msg->levels.size());
+  const auto initial_pose = _model->WorldPose();
+  const double x = initial_pose.Pos().X();
+  const double y = initial_pose.Pos().Y();
+
+  auto compute_disp = [&](const building_map_msgs::msg::GraphNode& v) -> double
+  {
+    return std::sqrt(
+        std::pow(x - v.x, 2) +
+        std::pow(y - v.y, 2));
+  };
+
+  // TODO be smarter about this search
+  // Check if robot is 1m from a waypoint in a level and if so set
+  // _current_level_name to that level.name
+  for (const auto& level : msg->levels)
+  {
+    for (const auto& graph : level.nav_graphs)
+    {
+      for (const auto& vertex : graph.vertices)
+      {
+        if (std::abs(compute_disp(vertex) - 0.0) < 1.0)
+        {
+          _current_level_name = level.name;
+          RCLCPP_INFO(logger(), "Setting slotcar level name [%s]",
+            level.name.c_str());
+          return;
+        }
+      }
+    }
+  }
+
 }
 
 GZ_REGISTER_MODEL_PLUGIN(SlotcarPlugin)


### PR DESCRIPTION
This PR addresses [issue 6](https://github.com/osrf/romi-dashboard/issues/4) for the romih dashboard.
To correctly initialize this `level_name` when the plugin is loaded, the plugin parses the `BuildingMap` msg as published by the `building_map_server` and identifies the level based on proximity of the spawned model to a waypoint on a level. Subsequently, the `level_name` is inferred from incoming `PathRequest` msgs which should take care of situations where the robot takes a lift to another level.