### PR TITLE
Fix/door elevation

### DIFF
--- a/building_map_tools/building_map/building.py
+++ b/building_map_tools/building_map/building.py
@@ -192,7 +192,7 @@ class Building:
             uri_ele = SubElement(level_include_ele, 'uri')
             uri_ele.text = f'model://{level_model_name}'
             pose_ele = SubElement(level_include_ele, 'pose')
-            pose_ele.text = f'0 0 {level.elevation/4} 0 0 0'
+            pose_ele.text = f'0 0 {level.elevation} 0 0 0'
 
         gui_ele = world.find('gui')
         c = self.center()

--- a/building_map_tools/building_map/doors/door.py
+++ b/building_map_tools/building_map/doors/door.py
@@ -2,12 +2,13 @@ from xml.etree.ElementTree import Element, SubElement
 
 
 class Door:
-    def __init__(self, door_edge):
+    def __init__(self, door_edge, level_elevation = 0.0):
         self.name = door_edge.params['name'].value
         self.type = door_edge.params['type'].value
         self.length = door_edge.length
         self.cx = door_edge.x
         self.cy = door_edge.y
+        self.cz = level_elevation
         self.yaw = door_edge.yaw
         self.height = 2.2  # parameterize someday?
         self.thickness = 0.03  # parameterize someday?
@@ -16,7 +17,7 @@ class Door:
         self.model_ele = Element('model')
         self.model_ele.set('name', self.name)
         pose_ele = SubElement(self.model_ele, 'pose')
-        pose_ele.text = f'{self.cx} {self.cy} 0 0 0 {self.yaw}'
+        pose_ele.text = f'{self.cx} {self.cy} {self.cz} 0 0 {self.yaw}'
 
     def generate_section(self, name, width, x_offset, options):
         link_ele = SubElement(self.model_ele, 'link')

--- a/building_map_tools/building_map/doors/door.py
+++ b/building_map_tools/building_map/doors/door.py
@@ -2,7 +2,7 @@ from xml.etree.ElementTree import Element, SubElement
 
 
 class Door:
-    def __init__(self, door_edge, level_elevation = 0.0):
+    def __init__(self, door_edge, level_elevation=0.0):
         self.name = door_edge.params['name'].value
         self.type = door_edge.params['type'].value
         self.length = door_edge.length

--- a/building_map_tools/building_map/doors/double_sliding_door.py
+++ b/building_map_tools/building_map/doors/double_sliding_door.py
@@ -3,8 +3,8 @@ from .door import Door
 
 
 class DoubleSlidingDoor(Door):
-    def __init__(self, door_edge):
-        super().__init__(door_edge)
+    def __init__(self, door_edge, level_elevation):
+        super().__init__(door_edge, level_elevation)
 
     def generate(self, world_ele, options):
         self.generate_sliding_section(

--- a/building_map_tools/building_map/doors/double_swing_door.py
+++ b/building_map_tools/building_map/doors/double_swing_door.py
@@ -3,8 +3,8 @@ from .door import Door
 
 
 class DoubleSwingDoor(Door):
-    def __init__(self, door_edge):
-        super().__init__(door_edge)
+    def __init__(self, door_edge, level_elevation):
+        super().__init__(door_edge, level_elevation)
         motion_degrees = door_edge.params['motion_degrees'].value
         self.motion_radians = 3.14 * motion_degrees / 180.0
         self.motion_direction = door_edge.params['motion_direction'].value

--- a/building_map_tools/building_map/doors/sliding_door.py
+++ b/building_map_tools/building_map/doors/sliding_door.py
@@ -3,8 +3,8 @@ from .door import Door
 
 
 class SlidingDoor(Door):
-    def __init__(self, door_edge):
-        super().__init__(door_edge)
+    def __init__(self, door_edge, level_elevation):
+        super().__init__(door_edge, level_elevation)
 
     def generate(self, world_ele, options):
         self.generate_sliding_section(

--- a/building_map_tools/building_map/doors/swing_door.py
+++ b/building_map_tools/building_map/doors/swing_door.py
@@ -3,8 +3,8 @@ from .door import Door
 
 
 class SwingDoor(Door):
-    def __init__(self, door_edge):
-        super().__init__(door_edge)
+    def __init__(self, door_edge, level_elevation):
+        super().__init__(door_edge, level_elevation)
         motion_degrees = door_edge.params['motion_degrees'].value
         self.motion_radians = 3.14 * motion_degrees / 180.0
         self.motion_direction = door_edge.params['motion_direction'].value

--- a/building_map_tools/building_map/level.py
+++ b/building_map_tools/building_map/level.py
@@ -101,6 +101,7 @@ class Level:
             v = copy.deepcopy(untransformed_vertex)
             transformed = self.transform.transform_point(v.xy())
             v.x, v.y = transformed
+            v.z = self.elevation
             self.transformed_vertices.append(v)
 
     def calculate_scale_using_measurements(self):
@@ -373,13 +374,13 @@ class Level:
 
         door = None
         if door_type == 'sliding':
-            door = SlidingDoor(door_edge)
+            door = SlidingDoor(door_edge, self.elevation)
         elif door_type == 'hinged':
-            door = SwingDoor(door_edge)
+            door = SwingDoor(door_edge, self.elevation)
         elif door_type == 'double_sliding':
-            door = DoubleSlidingDoor(door_edge)
+            door = DoubleSlidingDoor(door_edge, self.elevation)
         elif door_type == 'double_hinged':
-            door = DoubleSwingDoor(door_edge)
+            door = DoubleSwingDoor(door_edge, self.elevation)
         else:
             print(f'door type {door_type} not yet implemented')
 


### PR DESCRIPTION
This PR addresses Issue #126 . 
- Doors elements generated at corresponding `level.elevation`
- z-coordinate of transformed vertices set to `level.elevation` (allows for robots to be spawned at correct elevation)
- Corrected z-coordinate of level models in `generate_sdf_world()`

![image](https://user-images.githubusercontent.com/13482049/82141817-e5f1b600-986a-11ea-8610-ca7811c0e916.png)

