### PR TITLE
Fix not generating cropped image with namespace

### DIFF
--- a/traffic_editor/thumbnail_generator/scripts/crop.py
+++ b/traffic_editor/thumbnail_generator/scripts/crop.py
@@ -135,7 +135,7 @@ if __name__ == '__main__':
         )
 
         output_filepath = os.path.join(
-            os.path.abspath(args.output_dir),
+            os.path.expanduser(args.output_dir),
             '{}.png'.format(model_name)
         )
 


### PR DESCRIPTION
I opened [this issue about thumbnail generator](https://github.com/osrf/traffic_editor/issues/146) yesterday. I went through crop.py and found that when a namespace is used cv2.imwrite would not be able to generate the cropped image because a directory for the namespace needs to be created first, so I made some small changes to crop.py and added a mkdir for the author name