### PR TITLE
python line was too long

### DIFF
--- a/traffic_editor/thumbnail_generator/scripts/crop.py
+++ b/traffic_editor/thumbnail_generator/scripts/crop.py
@@ -119,7 +119,12 @@ if __name__ == '__main__':
 
         try:
             if author_name:
-                os.makedirs(os.path.join(os.path.expanduser(args.output_dir), author_name))
+                os.makedirs(
+                    os.path.join(
+                        os.path.expanduser(args.output_dir),
+                        author_name
+                    )
+                )
         except Exception as e:
             pass
 


### PR DESCRIPTION
Trivial fix following up on #147  just wrapping lines, so that the python style checker is happy.