### PR TITLE
Implement using thumbnails from installed traffic_editor_assets ament package

### DIFF
--- a/traffic_editor/CMakeLists.txt
+++ b/traffic_editor/CMakeLists.txt
@@ -26,6 +26,7 @@ endif()
 find_package(Qt5 COMPONENTS Widgets Concurrent REQUIRED)
 find_package(ignition-plugin1 REQUIRED COMPONENTS all)
 find_package(ignition-common3 REQUIRED)
+find_package(ament_index_cpp REQUIRED)
 
 # OpenCV is an optional dependency, only needed if you want to make videos
 # which is only really needed if you're using a process simulation plugin
@@ -34,6 +35,7 @@ find_package(OpenCV QUIET)
 include_directories(.)
 include_directories(gui)
 include_directories(include)
+include_directories(${ament_index_cpp_INCLUDE_DIRS})
 
 add_executable(traffic-editor
   gui/add_param_dialog.cpp
@@ -84,7 +86,9 @@ target_link_libraries(traffic-editor
   ignition-plugin1::loader
   ignition-common3::core
   yaml-cpp
-  ${OpenCV_LIBS})
+  ${ament_index_cpp_LIBRARIES}
+  ${OpenCV_LIBS}
+)
 
 if (OpenCV_VERSION)
   target_compile_definitions(traffic-editor PUBLIC "HAS_OPENCV")

--- a/traffic_editor/CMakeLists.txt
+++ b/traffic_editor/CMakeLists.txt
@@ -8,7 +8,6 @@ project(traffic_editor)
 
 find_package(yaml-cpp REQUIRED)
 find_package(ament_cmake REQUIRED)
-include(ExternalProject)
 
 set(CMAKE_BUILD_TYPE RelWithDebInfo)
 # set(CMAKE_VERBOSE_MAKEFILE TRUE)

--- a/traffic_editor/CMakeLists.txt
+++ b/traffic_editor/CMakeLists.txt
@@ -96,21 +96,6 @@ endif()
 
 set_property(TARGET traffic-editor PROPERTY ENABLE_EXPORTS 1)
 
-# Create assets folder directory, and clone it from git
-
-file(MAKE_DIRECTORY "$ENV{HOME}/.traffic_editor/")
-
-ExternalProject_Add(thumbnails_repo
-  GIT_REPOSITORY  https://github.com/osrf/traffic_editor_assets.git
-  GIT_TAG         master
-  INSTALL_COMMAND ""
-  BUILD_COMMAND ""
-  CONFIGURE_COMMAND ""
-  SOURCE_DIR "$ENV{HOME}/.traffic_editor/assets"
-)
-
-add_dependencies(traffic-editor thumbnails_repo)
-
 install(
   TARGETS traffic-editor
   LIBRARY DESTINATION lib

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -37,6 +37,9 @@
 
 #include <yaml-cpp/yaml.h>
 
+#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "ament_index_cpp/get_resource.hpp"
+
 #include "add_param_dialog.h"
 #include "building_dialog.h"
 #include "building_level_dialog.h"
@@ -476,20 +479,26 @@ void Editor::load_model_names()
       settings.value(preferences_keys::thumbnail_path).toString());
   if (thumbnail_path.isEmpty())
   {
-    std::string homedir;
+    std::string assets_dir;
+    std::string share_dir;
 
-    // Get home directory
-    homedir = getenv("HOME");
-    if ((homedir.c_str()) == NULL) {
-        homedir = getpwuid(getuid())->pw_dir;
-    }
-    // Currently not sure how to do this the "right" way. For now assume
-    // everybody is building from source, I guess (?).
-    // todo: figure out something better in the future for binary installs
+    share_dir =
+        ament_index_cpp::get_package_share_directory("traffic_editor_assets");
+
+    ament_index_cpp::get_resource("traffic_editor_assets",
+                                  "assets",
+                                  assets_dir);
+
+    // Strip newlines from assets_dir
+    assets_dir.erase(std::remove(assets_dir.begin(), assets_dir.end(), '\n'),
+                     assets_dir.end());
+
+    // Obtain thumbnail path from traffic_editor_assets ament package
     thumbnail_path =
         QDir::cleanPath(
-            QDir(QApplication::applicationDirPath()).filePath((homedir
-              + "/.traffic_editor/assets/thumbnails").c_str())
+            QDir(QApplication::applicationDirPath()).filePath(
+                (share_dir + "/" + assets_dir + "/thumbnails").c_str()
+            )
         );
     settings.setValue(preferences_keys::thumbnail_path, thumbnail_path);
   }

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -38,6 +38,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include "ament_index_cpp/get_package_share_directory.hpp"
+#include "ament_index_cpp/get_package_prefix.hpp"
 #include "ament_index_cpp/get_resource.hpp"
 
 #include "add_param_dialog.h"
@@ -482,12 +483,18 @@ void Editor::load_model_names()
     std::string assets_dir;
     std::string share_dir;
 
-    share_dir =
-        ament_index_cpp::get_package_share_directory("traffic_editor_assets");
+    try {
+      share_dir =
+          ament_index_cpp::get_package_share_directory("traffic_editor_assets");
 
-    ament_index_cpp::get_resource("traffic_editor_assets",
-                                  "assets",
-                                  assets_dir);
+      ament_index_cpp::get_resource("traffic_editor_assets",
+                                    "assets",
+                                    assets_dir);
+    } catch (const ament_index_cpp::PackageNotFoundError& e) {
+      qWarning("Could not load default thumbnail directory! "
+               "traffic_editor_assets package not found in workspace!");
+      return;
+    }
 
     // Strip newlines from assets_dir
     assets_dir.erase(std::remove(assets_dir.begin(), assets_dir.end(), '\n'),

--- a/traffic_editor/package.xml
+++ b/traffic_editor/package.xml
@@ -12,7 +12,9 @@
   <build_depend>traffic_editor_assets</build_depend>
   <build_depend>libignition-plugin-dev</build_depend>
   <build_depend>libignition-common3</build_depend>
-  
+
+    <exec_depend>traffic_editor_assets</exec_depend>
+    
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/traffic_editor/package.xml
+++ b/traffic_editor/package.xml
@@ -9,11 +9,8 @@
 
   <build_depend>ament_cmake</build_depend>
   <build_depend>ament_index_cpp</build_depend>
-  <build_depend>traffic_editor_assets</build_depend>
   <build_depend>libignition-plugin-dev</build_depend>
   <build_depend>libignition-common3</build_depend>
-
-  <exec_depend>traffic_editor_assets</exec_depend>
     
   <export>
     <build_type>ament_cmake</build_type>

--- a/traffic_editor/package.xml
+++ b/traffic_editor/package.xml
@@ -8,6 +8,8 @@
   <license>Apache License 2.0</license>
 
   <build_depend>ament_cmake</build_depend>
+  <build_depend>ament_index_cpp</build_depend>
+  <build_depend>traffic_editor_assets</build_depend>
   <build_depend>libignition-plugin-dev</build_depend>
   <build_depend>libignition-common3</build_depend>
   

--- a/traffic_editor/package.xml
+++ b/traffic_editor/package.xml
@@ -13,7 +13,7 @@
   <build_depend>libignition-plugin-dev</build_depend>
   <build_depend>libignition-common3</build_depend>
 
-    <exec_depend>traffic_editor_assets</exec_depend>
+  <exec_depend>traffic_editor_assets</exec_depend>
     
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
With the change in `traffic_editor_assets` in https://github.com/osrf/traffic_editor_assets/pull/5 , there is no longer any need to pull the repository on build! This means that you no longer need an internet connection to have a successful build.

Instead, simply build `traffic_editor_assets` and `traffic_editor` will take care of the rest, dynamically resolving the location of `traffic_editor_asset`'s thumbnail directory instead of using a hidden folder in your home directory!

## Testing
To test it, remember to remove the default preferences from `traffic_editor` in `~/.config/open-robotics` so that it will search for the default thumbnail path.

Then run `traffic-editor` and watch the console for its efforts in locating the `traffic_editor_assets` package (make sure the assets package is built and the workspace is sourced, of course!), and verify that the thumbnails could be found by trying to add a model.