### PR TITLE
Allowed test_map to build without model downloading

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,4 +37,4 @@ jobs:
       run: |
         cd ws
         source /opt/ros/eloquent/setup.bash
-        colcon build --packages-select traffic_editor
+        colcon build --packages-select traffic_editor --cmake-args -DNO_DOWNLOAD_MODELS=True

--- a/test_maps/CMakeLists.txt
+++ b/test_maps/CMakeLists.txt
@@ -28,10 +28,14 @@ foreach(path ${traffic_editor_paths})
   set(output_model_dir ${output_dir}/models)
 
   # first, generate the world
+  set(no_download_flag "")
+  if (NO_DOWNLOAD_MODELS)
+    set(no_download_flag "--no_download")
+  endif()
   message("BUILDING WORLDFILE WITH COMMAND: ros2 run building_map_tools building_map_generator gazebo ${map_path} ${output_world_path} ${output_model_dir}")
   add_custom_command(
     OUTPUT ${output_world_path}
-    COMMAND ros2 run building_map_tools building_map_generator gazebo ${map_path} ${output_world_path} ${output_model_dir}
+    COMMAND ros2 run building_map_tools building_map_generator gazebo ${map_path} ${output_world_path} ${output_model_dir} ${no_download_flag}
     DEPENDS ${map_path}
   )
 


### PR DESCRIPTION
* added reading CMAKE flag to prevent model downloading for build tests
* added flag during build test for `traffic_editor`, just in case needed for dependencies