### PR TITLE
consistent handling of model angles. Add GUI to transform all model yaw

### DIFF
--- a/building_map_tools/building_map/model.py
+++ b/building_map_tools/building_map/model.py
@@ -39,7 +39,7 @@ class Model:
         pose_ele = SubElement(include_ele, 'pose')
         x, y = transform.transform_point((self.x, self.y))
         z = self.z
-        yaw = self.yaw + 1.5707 + transform.rotation
+        yaw = self.yaw + transform.rotation
         pose_ele.text = f'{x} {y} {z} 0 0 {yaw}'
 
         static_ele = SubElement(include_ele, 'static')

--- a/traffic_editor/gui/building.cpp
+++ b/traffic_editor/gui/building.cpp
@@ -641,3 +641,10 @@ bool Building::get_model(const string& instance_name, Model&& _model)
       }
   return false;
 }
+
+void Building::rotate_all_models(const double rotation)
+{
+  for (auto& level : levels)
+    for (auto& model : level.models)
+      model.state.yaw += rotation;
+}

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -55,6 +55,7 @@
 #include "project_dialog.h"
 #include "scenario_table.h"
 #include "traffic_table.h"
+#include "ui_transform_dialog.h"
 
 using std::string;
 using std::isnan;
@@ -268,6 +269,11 @@ Editor::Editor()
       "&Project properties...",
       this,
       &Editor::edit_project_properties);
+  edit_menu->addSeparator();
+  edit_menu->addAction(
+      "&Transform...",
+      this,
+      &Editor::edit_transform);
   edit_menu->addSeparator();
   edit_menu->addAction("&Preferences...", this, &Editor::edit_preferences);
 
@@ -744,6 +750,21 @@ void Editor::edit_project_properties()
   ProjectDialog project_dialog(project);
   if (project_dialog.exec() == QDialog::Accepted)
     setWindowModified(true);
+}
+
+void Editor::edit_transform()
+{
+  QDialog dialog;
+  Ui::TransformDialog dialog_ui;
+  dialog_ui.setupUi(&dialog);
+  if (dialog.exec() != QDialog::Accepted)
+    return;
+
+  const double rotation =
+      dialog_ui.rotate_all_models_line_edit->text().toDouble();
+  project.building.rotate_all_models(rotation);
+  create_scene();
+  setWindowModified(true);
 }
 
 void Editor::zoom_fit()
@@ -1875,7 +1896,7 @@ void Editor::mouse_rotate(
 
     if (mouse_motion_model)
       mouse_motion_model->setRotation(
-          -(mouse_yaw + M_PI / 2.0) * 180.0 / M_PI);
+          (-mouse_yaw + M_PI / 2.0) * 180.0 / M_PI);
   }
 }
 

--- a/traffic_editor/gui/editor.h
+++ b/traffic_editor/gui/editor.h
@@ -133,6 +133,7 @@ private:
   void edit_preferences();
   void edit_building_properties();
   void edit_project_properties();
+  void edit_transform();
 
   void level_add();
   void level_edit();

--- a/traffic_editor/gui/model.cpp
+++ b/traffic_editor/gui/model.cpp
@@ -202,7 +202,7 @@ void Model::draw(
   }
 
   pixmap_item->setPos(state.x, state.y);
-  pixmap_item->setRotation(-state.yaw * 180.0 / M_PI);
+  pixmap_item->setRotation((-state.yaw + M_PI / 2.0) * 180.0 / M_PI);
 
   // make the model "glow" if it is selected
   if (selected)

--- a/traffic_editor/gui/transform_dialog.ui
+++ b/traffic_editor/gui/transform_dialog.ui
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TransformDialog</class>
+ <widget class="QDialog" name="TransformDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>379</width>
+    <height>152</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="rotate_all_models_label">
+     <property name="text">
+      <string>Rotate all models:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="rotate_all_models_line_edit">
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::MinimumExpanding</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>TransformDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>273</x>
+     <y>121</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>189</x>
+     <y>75</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>TransformDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>273</x>
+     <y>121</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>189</x>
+     <y>75</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/traffic_editor/include/traffic_editor/building.h
+++ b/traffic_editor/include/traffic_editor/building.h
@@ -166,6 +166,8 @@ public:
   double level_meters_per_pixel(const std::string& level_name) const;
 
   bool get_model(const std::string& name, Model&& model);
+
+  void rotate_all_models(const double rotation);
 };
 
 #endif


### PR DESCRIPTION
Fix #156  by migrating towards the "typical" Cartesian angle convention of 0 radians = east, pi/2 radians = north. Because Qt uses the "geographic" convention of zero degrees = north, 90 degrees = east, we've flip-flopped on this a bit.

To deal with the past, there is now a GUI dialog in `Edit->Transform` that lets you enter an angle offset to "fix" maps that have the opposite convention. `Edit->Transform...` will instantly "fix" the `rmf_demos` office and airport maps if you enter `1.5708` :sparkles: 