### PR TITLE
Add missing includes and namespace usages for math functions

### DIFF
--- a/traffic_editor/gui/building_level.cpp
+++ b/traffic_editor/gui/building_level.cpp
@@ -16,6 +16,7 @@
 */
 
 #include <algorithm>
+#include <cmath>
 
 #include <QGraphicsOpacityEffect>
 #include <QGraphicsPixmapItem>
@@ -337,7 +338,7 @@ void BuildingLevel::calculate_scale()
       scale_count++;
       const double dx = vertices[edge.start_idx].x - vertices[edge.end_idx].x;
       const double dy = vertices[edge.start_idx].y - vertices[edge.end_idx].y;
-      const double distance_pixels = sqrt(dx*dx + dy*dy);
+      const double distance_pixels = std::sqrt(dx*dx + dy*dy);
       // todo: a clean, strongly-typed parameter API for edges
       const double distance_meters =
           edge.params[std::string("distance")].value_double;
@@ -377,7 +378,7 @@ void BuildingLevel::draw_lane(
   const auto &v_end = vertices[edge.end_idx];
   const double dx = v_end.x - v_start.x;
   const double dy = v_end.y - v_start.y;
-  const double len = sqrt(dx*dx + dy*dy);
+  const double len = std::sqrt(dx*dx + dy*dy);
 
   const double lane_pen_width = 1.0 / drawing_meters_per_pixel;
 
@@ -449,7 +450,7 @@ void BuildingLevel::draw_lane(
     // draw robot-outline box midway down this lane
     const double mx = (v_start.x + v_end.x) / 2.0;
     const double my = (v_start.y + v_end.y) / 2.0;
-    const double yaw = atan2(norm_y, norm_x);
+    const double yaw = std::atan2(norm_y, norm_x);
 
     // robot-box half-dimensions in meters
     const double rw = 0.4 / drawing_meters_per_pixel;
@@ -460,26 +461,26 @@ void BuildingLevel::draw_lane(
     // front-left
     // |mx| + |cos -sin| | rl|
     // |my|   |sin  cos| | rw|
-    const double flx = mx + rl * cos(yaw) - rw * sin(yaw);
-    const double fly = my + rl * sin(yaw) + rw * cos(yaw);
+    const double flx = mx + rl * std::cos(yaw) - rw * std::sin(yaw);
+    const double fly = my + rl * std::sin(yaw) + rw * std::cos(yaw);
 
     // front-right
     // |mx| + |cos -sin| | rl|
     // |my|   |sin  cos| |-rw|
-    const double frx = mx + rl * cos(yaw) + rw * sin(yaw);
-    const double fry = my + rl * sin(yaw) - rw * cos(yaw);
+    const double frx = mx + rl * std::cos(yaw) + rw * std::sin(yaw);
+    const double fry = my + rl * std::sin(yaw) - rw * std::cos(yaw);
 
     // back-left
     // |mx| + |cos -sin| |-rl|
     // |my|   |sin  cos| | rw|
-    const double blx = mx - rl * cos(yaw) - rw * sin(yaw);
-    const double bly = my - rl * sin(yaw) + rw * cos(yaw);
+    const double blx = mx - rl * std::cos(yaw) - rw * std::sin(yaw);
+    const double bly = my - rl * std::sin(yaw) + rw * std::cos(yaw);
 
     // back-right
     // |mx| + |cos -sin| |-rl|
     // |my|   |sin  cos| |-rw|
-    const double brx = mx - rl * cos(yaw) + rw * sin(yaw);
-    const double bry = my - rl * sin(yaw) - rw * cos(yaw);
+    const double brx = mx - rl * std::cos(yaw) + rw * std::sin(yaw);
+    const double bry = my - rl * std::sin(yaw) - rw * std::cos(yaw);
 
     QPainterPath pp;
     pp.moveTo(QPointF(flx, fly));
@@ -566,8 +567,8 @@ void BuildingLevel::draw_door(QGraphicsScene *scene, const Edge &edge) const
 
   const double door_dx = v_end.x - v_start.x;
   const double door_dy = v_end.y - v_start.y;
-  const double door_length = sqrt(door_dx * door_dx + door_dy * door_dy);
-  const double door_angle = atan2(door_dy, door_dx);
+  const double door_length = std::sqrt(door_dx * door_dx + door_dy * door_dy);
+  const double door_angle = std::atan2(door_dy, door_dx);
 
   auto door_type_it = edge.params.find("type");
   if (door_type_it != edge.params.end())
@@ -662,8 +663,8 @@ void BuildingLevel::add_door_slide_path(
   // first draw the door as a thin line
   path.moveTo(hinge_x, hinge_y);
   path.lineTo(
-      hinge_x + door_length * cos(door_angle),
-      hinge_y + door_length * sin(door_angle));
+      hinge_x + door_length * std::cos(door_angle),
+      hinge_y + door_length * std::sin(door_angle));
 
   // now draw a box around where it slides (in the wall, usually)
   const double th = door_angle;  // makes expressions below single-line...
@@ -671,20 +672,20 @@ void BuildingLevel::add_door_slide_path(
   const double s = 0.15 / drawing_meters_per_pixel;  // sliding panel thickness
 
   const QPointF p1(
-      hinge_x - s * cos(th + pi_2),
-      hinge_y - s * sin(th + pi_2));
+      hinge_x - s * std::cos(th + pi_2),
+      hinge_y - s * std::sin(th + pi_2));
 
   const QPointF p2(
-      hinge_x - s * cos(th + pi_2) - door_length * cos(th),
-      hinge_y - s * sin(th + pi_2) - door_length * sin(th));
+      hinge_x - s * std::cos(th + pi_2) - door_length * std::cos(th),
+      hinge_y - s * std::sin(th + pi_2) - door_length * std::sin(th));
 
   const QPointF p3(
-      hinge_x + s * cos(th + pi_2) - door_length * cos(th),
-      hinge_y + s * sin(th + pi_2) - door_length * sin(th));
+      hinge_x + s * std::cos(th + pi_2) - door_length * std::cos(th),
+      hinge_y + s * std::sin(th + pi_2) - door_length * std::sin(th));
 
   const QPointF p4(
-      hinge_x + s * cos(th + pi_2),
-      hinge_y + s * sin(th + pi_2));
+      hinge_x + s * std::cos(th + pi_2),
+      hinge_y + s * std::sin(th + pi_2));
 
 
   path.moveTo(p1);
@@ -704,8 +705,8 @@ void BuildingLevel::add_door_swing_path(
 {
   path.moveTo(hinge_x, hinge_y);
   path.lineTo(
-      hinge_x + door_length * cos(start_angle),
-      hinge_y + door_length * sin(start_angle));
+      hinge_x + door_length * std::cos(start_angle),
+      hinge_y + door_length * std::sin(start_angle));
 
   const int NUM_MOTION_STEPS = 10;
   const double angle_inc = (end_angle - start_angle) / (NUM_MOTION_STEPS-1);
@@ -715,8 +716,8 @@ void BuildingLevel::add_door_swing_path(
     const double a = start_angle + i * angle_inc;
 
     path.lineTo(
-        hinge_x + door_length * cos(a),
-        hinge_y + door_length * sin(a));
+        hinge_x + door_length * std::cos(a),
+        hinge_y + door_length * std::sin(a));
   }
 
   path.lineTo(hinge_x, hinge_y);

--- a/traffic_editor/gui/fiducial.cpp
+++ b/traffic_editor/gui/fiducial.cpp
@@ -15,6 +15,8 @@
  *
 */
 
+#include <cmath>
+
 #include <QGraphicsScene>
 #include <QGraphicsSimpleTextItem>
 
@@ -45,8 +47,8 @@ YAML::Node Fiducial::to_yaml() const
   // with more than 1/1000 precision inside a single pixel.
   YAML::Node node;
   node.SetStyle(YAML::EmitterStyle::Flow);
-  node.push_back(round(x * 1000.0) / 1000.0);
-  node.push_back(round(y * 1000.0) / 1000.0);
+  node.push_back(std::round(x * 1000.0) / 1000.0);
+  node.push_back(std::round(y * 1000.0) / 1000.0);
   node.push_back(name);
   return node;
 }
@@ -84,5 +86,5 @@ double Fiducial::distance(const Fiducial& f)
 {
   const double dx = f.x - x;
   const double dy = f.y - y;
-  return sqrt(dx*dx + dy*dy);
+  return std::sqrt(dx*dx + dy*dy);
 }

--- a/traffic_editor/gui/level.cpp
+++ b/traffic_editor/gui/level.cpp
@@ -16,6 +16,7 @@
 */
 
 #include <algorithm>
+#include <cmath>
 
 #include <QGraphicsScene>
 #include <QImage>
@@ -78,7 +79,7 @@ double Level::point_to_line_segment_distance(
   const double dx_proj = x - x_proj;
   const double dy_proj = y - y_proj;
 
-  const double dist = sqrt(dx_proj * dx_proj + dy_proj * dy_proj);
+  const double dist = std::sqrt(dx_proj * dx_proj + dy_proj * dy_proj);
 
   /*
   printf("   p=(%.1f, %.1f) p0=(%.1f, %.1f) p1=(%.1f, %.1f) t=%.3f proj=(%.1f, %.1f) dist=%.3f\n",

--- a/traffic_editor/gui/lift.cpp
+++ b/traffic_editor/gui/lift.cpp
@@ -16,6 +16,7 @@
 */
 
 #include <algorithm>
+#include <cmath>
 
 #include <QGraphicsScene>
 #include <QGraphicsSimpleTextItem>
@@ -77,13 +78,13 @@ YAML::Node Lift::to_yaml() const
   // with more than 1/1000 precision inside a single pixel.
 
   YAML::Node n;
-  n["x"] = round(x * 1000.0) / 1000.0;
-  n["y"] = round(y * 1000.0) / 1000.0;
+  n["x"] = std::round(x * 1000.0) / 1000.0;
+  n["y"] = std::round(y * 1000.0) / 1000.0;
   // let's give yaw another decimal place because, I don't know, reasons (?)
-  n["yaw"] = round(yaw * 10000.0) / 10000.0;
+  n["yaw"] = std::round(yaw * 10000.0) / 10000.0;
   n["reference_floor_name"] = reference_floor_name;
-  n["width"] = round(width * 1000.0) / 1000.0;
-  n["depth"] = round(depth * 1000.0) / 1000.0;
+  n["width"] = std::round(width * 1000.0) / 1000.0;
+  n["depth"] = std::round(depth * 1000.0) / 1000.0;
 
   n["doors"] = YAML::Node(YAML::NodeType::Map);
   for (const auto& door : doors)

--- a/traffic_editor/gui/lift_door.cpp
+++ b/traffic_editor/gui/lift_door.cpp
@@ -15,6 +15,8 @@
  *
 */
 
+#include <cmath>
+
 #include "traffic_editor/lift_door.h"
 
 YAML::Node LiftDoor::to_yaml() const
@@ -23,13 +25,13 @@ YAML::Node LiftDoor::to_yaml() const
   // with more than 1/1000 precision inside a single pixel.
 
   YAML::Node n;
-  n["x"] = round(x * 1000.0) / 1000.0;
-  n["y"] = round(y * 1000.0) / 1000.0;
-  n["width"] = round(width * 1000.0) / 1000.0;
+  n["x"] = std::round(x * 1000.0) / 1000.0;
+  n["y"] = std::round(y * 1000.0) / 1000.0;
+  n["width"] = std::round(width * 1000.0) / 1000.0;
   n["door_type"] = static_cast<int>(door_type);
   // let's give yaw another decimal place because, I don't know, reasons (?)
   n["motion_axis_orientation"] =
-      round(motion_axis_orientation * 10000.0) / 10000.0;
+      std::round(motion_axis_orientation * 10000.0) / 10000.0;
   return n;
 }
 

--- a/traffic_editor/gui/model.cpp
+++ b/traffic_editor/gui/model.cpp
@@ -15,6 +15,8 @@
  *
 */
 
+#include <cmath>
+
 #include <QtGlobal>
 #include <QGraphicsPixmapItem>
 #include <QGraphicsColorizeEffect>
@@ -73,11 +75,11 @@ YAML::Node Model::to_yaml() const
 
   YAML::Node n;
   n.SetStyle(YAML::EmitterStyle::Flow);
-  n["x"] = round(state.x * 1000.0) / 1000.0;
-  n["y"] = round(state.y * 1000.0) / 1000.0;
-  n["z"] = round(state.z * 1000.0) / 1000.0;
+  n["x"] = std::round(state.x * 1000.0) / 1000.0;
+  n["y"] = std::round(state.y * 1000.0) / 1000.0;
+  n["z"] = std::round(state.z * 1000.0) / 1000.0;
   // let's give yaw another decimal place because, I don't know, reasons (?)
-  n["yaw"] = round(state.yaw * 10000.0) / 10000.0;
+  n["yaw"] = std::round(state.yaw * 10000.0) / 10000.0;
   n["name"] = instance_name;
   n["model_name"] = model_name;
   n["static"] = is_static;

--- a/traffic_editor/gui/project.cpp
+++ b/traffic_editor/gui/project.cpp
@@ -15,6 +15,7 @@
  *
 */
 
+#include <cmath>
 #include <fstream>
 
 #include "project.h"
@@ -258,7 +259,7 @@ Project::NearestItem Project::nearest_items(
       const Vertex& p = building_level.vertices[i];
       const double dx = x - p.x;
       const double dy = y - p.y;
-      const double dist = sqrt(dx*dx + dy*dy);
+      const double dist = std::sqrt(dx*dx + dy*dy);
       if (dist < ni.vertex_dist)
       {
         ni.vertex_dist = dist;
@@ -271,7 +272,7 @@ Project::NearestItem Project::nearest_items(
       const Fiducial& f = building_level.fiducials[i];
       const double dx = x - f.x;
       const double dy = y - f.y;
-      const double dist = sqrt(dx*dx + dy*dy);
+      const double dist = std::sqrt(dx*dx + dy*dy);
       if (dist < ni.fiducial_dist)
       {
         ni.fiducial_dist = dist;
@@ -284,7 +285,7 @@ Project::NearestItem Project::nearest_items(
       const Model& m = building_level.models[i];
       const double dx = x - m.state.x;
       const double dy = y - m.state.y;
-      const double dist = sqrt(dx*dx + dy*dy);  // no need for sqrt each time
+      const double dist = std::sqrt(dx*dx + dy*dy);  // no need for sqrt each time
       if (dist < ni.model_dist)
       {
         ni.model_dist = dist;
@@ -309,7 +310,7 @@ Project::NearestItem Project::nearest_items(
         const Vertex& p = scenario_level.vertices[i];
         const double dx = x - p.x;
         const double dy = y - p.y;
-        const double dist = sqrt(dx*dx + dy*dy);
+        const double dist = std::sqrt(dx*dx + dy*dy);
         if (dist < ni.vertex_dist)
         {
           ni.vertex_dist = dist;
@@ -486,8 +487,8 @@ void Project::set_selected_line_item(
     const double dy1 = v_start.y - y1;
     const double dx2 = v_end.x - x2;
     const double dy2 = v_end.y - y2;
-    const double v1_dist = sqrt(dx1*dx1 + dy1*dy1);
-    const double v2_dist = sqrt(dx2*dx2 + dy2*dy2);
+    const double v1_dist = std::sqrt(dx1*dx1 + dy1*dy1);
+    const double v2_dist = std::sqrt(dx2*dx2 + dy2*dy2);
 
     const double thresh = 10.0;  // it should be really tiny if it matches
     if (v1_dist < thresh && v2_dist < thresh)

--- a/traffic_editor/gui/vertex.cpp
+++ b/traffic_editor/gui/vertex.cpp
@@ -15,6 +15,8 @@
  *
 */
 
+#include <cmath>
+
 #include <QGraphicsScene>
 #include <QGraphicsSimpleTextItem>
 
@@ -74,8 +76,8 @@ YAML::Node Vertex::to_yaml() const
 
   YAML::Node vertex_node;
   vertex_node.SetStyle(YAML::EmitterStyle::Flow);
-  vertex_node.push_back(round(x * 1000.0) / 1000.0);
-  vertex_node.push_back(round(y * 1000.0) / 1000.0);
+  vertex_node.push_back(std::round(x * 1000.0) / 1000.0);
+  vertex_node.push_back(std::round(y * 1000.0) / 1000.0);
   vertex_node.push_back(0.0);  // placeholder for Z offsets in the future
   vertex_node.push_back(name);
 

--- a/traffic_editor/gui/yaml_utils.cpp
+++ b/traffic_editor/gui/yaml_utils.cpp
@@ -15,6 +15,8 @@
  *
 */
 
+#include <algorithm>
+
 #include "yaml_utils.h"
 
 #include <string>


### PR DESCRIPTION
g++-9 and/or C++11/14 require the `cmath` header and `std::` namespace on various math functions used in the traffic editor GUI. g++8 probably wasn't being strict about these. Focal uses g++9 by default so they need to be fixed.