### PR TITLE
Handle missing directories in pit_crew

### DIFF
--- a/building_map_tools/pit_crew/pit_crew.py
+++ b/building_map_tools/pit_crew/pit_crew.py
@@ -95,7 +95,6 @@ def swag(print_swag=True):
 # MODEL PARSING
 ###############################################################################
 
-
 def get_missing_models(model_names, model_path=None,
                        config_file="model.config",
                        cache_file_path=None, update_cache=True, lower=True,

--- a/building_map_tools/pit_crew/pit_crew.py
+++ b/building_map_tools/pit_crew/pit_crew.py
@@ -241,8 +241,10 @@ def get_local_model_name_tuples(path=None, config_file="model.config",
     if not path.endswith("/"):
         path += "/"
 
-    assert os.path.isdir(path), \
-        "Path given must be a directory that exists!"
+    if not os.path.isdir(path):
+        logger.warning("Model directory specified does not exist! "
+                       "Returning empty model set.")
+        return output
 
     if ign:
         model_dir_iter = glob.glob(path + "*/*/models/*/")
@@ -490,8 +492,12 @@ def download_model(model_name, author_name, version="tip",
                            % download_path)
         else:
             download_path = os.path.expanduser(download_path)
-            assert os.path.isdir(download_path), \
-                "Path given must be a directory that exists!"
+
+        # Make directory if missing
+        if not os.path.isdir(download_path):
+            os.makedirs(download_path, exist_ok=True)
+            logger.warning("Download path does not exist! Created: %s"
+                           % download_path)
 
         url_base = "https://fuel.ignitionrobotics.org/1.0"
         metadata = requests.get("%s/%s/models/%s/%s/%s"


### PR DESCRIPTION
#163 highlighted an issue when a user's Gazebo model directory does not exist.

This PR fixes that issue.

For output directories, it creates them.
For parsed directories, it logs a warning instead of throwing an assertion, and follows behaviour as if the parsed directory were empty instead of non-existent.