### PR TITLE
Use C++17 standard to match SDFormat9 requirement

### DIFF
--- a/building_gazebo_plugins/CMakeLists.txt
+++ b/building_gazebo_plugins/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT CMAKE_C_STANDARD)
   set(CMAKE_C_STANDARD 99)
 endif()
 
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()

--- a/building_gazebo_plugins/CMakeLists.txt
+++ b/building_gazebo_plugins/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 


### PR DESCRIPTION
SDFormat version 9 [requires C++17](http://sdformat.org/tutorials?tut=roadmap). It uses `std::variant` which is only available from C++17 onwards. This PR changes the C++ version for the `building_gazebo_plugins` package.

This should be held until after the release.