### PR TITLE
Correct dependee to python3-shapely

### DIFF
--- a/building_map_tools/package.xml
+++ b/building_map_tools/package.xml
@@ -12,7 +12,7 @@
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>building_map_msgs</exec_depend>
   <exec_depend>ament_index_python</exec_depend>
-  <exec_depend>python-shapely</exec_depend>
+  <exec_depend>python3-shapely</exec_depend>
 
   <export>
     <build_type>ament_python</build_type>


### PR DESCRIPTION
Starting from Ubuntu Focal, depending on `python-shapely` won't work. There is a separate `rosdep` key for the Python 3 version of the package, `python3-shapely`. This package also exists on Ubuntu Bionic, so the dependency is changed to `python3-shapely`.