### PR TITLE
Add add_edge Shift key alignment feature

### DIFF
--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -1688,6 +1688,14 @@ void Editor::mouse_add_edge(
     const QPointF &p,
     const Edge::Type &edge_type)
 {
+  QPointF p_aligned(p);
+  if (clicked_idx >= 0 && e->modifiers() & Qt::ShiftModifier)
+  {
+    const auto& start =
+      project.building.levels[level_idx].vertices[clicked_idx];
+    align_point(QPointF(start.x, start.y), p_aligned);
+  }
+
   if (t == MOUSE_PRESS)
   {
     if (e->buttons() & Qt::RightButton)
@@ -1700,12 +1708,12 @@ void Editor::mouse_add_edge(
 
     const int prev_clicked_idx = clicked_idx;
     clicked_idx = project.building.nearest_item_index_if_within_distance(
-        level_idx, p.x(), p.y(), 10.0, Building::VERTEX);
+        level_idx, p_aligned.x(), p_aligned.y(), 10.0, Building::VERTEX);
 
     if (clicked_idx < 0)
     {
       // current click is not on an existing vertex. Add one.
-      project.building.add_vertex(level_idx, p.x(), p.y());
+      project.building.add_vertex(level_idx, p_aligned.x(), p_aligned.y());
 
       // set the new vertex as "clicked_idx"  todo: encapsulate better
       clicked_idx =
@@ -1749,7 +1757,8 @@ void Editor::mouse_add_edge(
   {
     if (clicked_idx < 0)
       return;
-    draw_mouse_motion_line_item(p.x(), p.y());
+
+    draw_mouse_motion_line_item(p_aligned.x(), p_aligned.y());
   }
 }
 
@@ -1821,6 +1830,13 @@ double Editor::discretize_angle(const double &angle)
 {
   const double discretization = 45.0 * M_PI / 180.0;
   return discretization * round(angle / discretization);
+}
+
+void Editor::align_point(const QPointF &start, QPointF &end){
+  if (qAbs(start.x() - end.x()) < qAbs(start.y() - end.y()))
+    end.setX(start.x());
+  else
+    end.setY(start.y());
 }
 
 void Editor::mouse_rotate(

--- a/traffic_editor/gui/editor.h
+++ b/traffic_editor/gui/editor.h
@@ -294,6 +294,7 @@ private:
 
   QGraphicsPixmapItem *get_closest_pixmap_item(const QPointF &p);
   double discretize_angle(const double &angle);
+  void align_point(const QPointF &start, QPointF &end);
 
   void mouse_select(const MouseType t, QMouseEvent *e, const QPointF &p);
   void mouse_move(const MouseType t, QMouseEvent *e, const QPointF &p);


### PR DESCRIPTION
Signed-off-by: Chen Bainian <brian97cbn@gmail.com>

This will allow add_edge function to snap either vertically or horizontally when **Shift** key is pressed.
I think this is especially good for alignment as #141 pointed out, This feature can also coexist with 141.

I follow the style of rotation. I will address the mouse_move part in a later PR since there are more changes.