### PR TITLE
view menu option to show/hide models

### DIFF
--- a/traffic_editor/gui/building_level.cpp
+++ b/traffic_editor/gui/building_level.cpp
@@ -834,8 +834,11 @@ void BuildingLevel::draw(
     item->setGraphicsEffect(opacity_effect);
   }
 
-  for (Model& model : models)
-    model.draw(scene, editor_models, drawing_meters_per_pixel);
+  if (rendering_options.show_models)
+  {
+    for (Model& model : models)
+      model.draw(scene, editor_models, drawing_meters_per_pixel);
+  }
 
   for (const auto& edge : edges)
   {

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -299,6 +299,11 @@ Editor::Editor()
 
   // VIEW MENU
   QMenu *view_menu = menuBar()->addMenu("&View");
+  view_models_action =
+      view_menu->addAction("&Models", this, &Editor::view_models);
+  view_models_action->setCheckable(true);
+  view_models_action->setChecked(true);
+  view_menu->addSeparator();
 
   zoom_fit_action =
       view_menu->addAction("&Fit to Window", this, &Editor::zoom_fit);
@@ -765,6 +770,12 @@ void Editor::edit_transform()
   project.building.rotate_all_models(rotation);
   create_scene();
   setWindowModified(true);
+}
+
+void Editor::view_models()
+{
+  project.rendering_options.show_models = view_models_action->isChecked();
+  create_scene();
 }
 
 void Editor::zoom_fit()

--- a/traffic_editor/gui/editor.h
+++ b/traffic_editor/gui/editor.h
@@ -140,6 +140,7 @@ private:
   void update_level_buttons();
 
   void zoom_fit();
+  void view_models();
 
   void help_about();
 
@@ -171,6 +172,7 @@ private:
   QAction *save_action;
   QAction *zoom_in_action, *zoom_out_action;
   QAction *zoom_normal_action, *zoom_fit_action;
+  QAction *view_models_action;
 
   const QString tool_id_to_string(const int id);
   QButtonGroup *tool_button_group;

--- a/traffic_editor/gui/project.cpp
+++ b/traffic_editor/gui/project.cpp
@@ -208,7 +208,7 @@ void Project::draw(
 
   building.levels[level_idx].draw(scene, editor_models, rendering_options);
   building.draw_lifts(scene, level_idx);
-  
+
   if (scenario_idx >= 0)
     scenarios[scenario_idx]->draw(
         scene,
@@ -362,7 +362,9 @@ void Project::mouse_select_press(
     const double model_dist_thresh = 0.5 /
         building.levels[level_idx].drawing_meters_per_pixel;
 
-    if (ni.model_idx >= 0 && ni.model_dist < model_dist_thresh)
+    if (rendering_options.show_models &&
+        ni.model_idx >= 0 &&
+        ni.model_dist < model_dist_thresh)
       building.levels[level_idx].models[ni.model_idx].selected = true;
     else if (ni.vertex_idx >= 0 && ni.vertex_dist < vertex_dist_thresh)
       building.levels[level_idx].vertices[ni.vertex_idx].selected = true;
@@ -381,11 +383,11 @@ void Project::mouse_select_press(
                 qgraphicsitem_cast<QGraphicsLineItem *>(graphics_item),
                 mode);
             break;
-    
+
           case QGraphicsPolygonItem::Type:
             set_selected_containing_polygon(mode, level_idx, x, y);
             break;
-    
+
           default:
             printf("clicked unhandled type: %d\n",
                 static_cast<int>(graphics_item->type()));
@@ -414,7 +416,7 @@ void Project::mouse_select_press(
                 qgraphicsitem_cast<QGraphicsLineItem *>(graphics_item),
                 mode);
             break;
-   
+
           default:
             printf("clicked unhandled type: %d\n",
                 static_cast<int>(graphics_item->type()));
@@ -438,7 +440,7 @@ void Project::mouse_select_press(
           case QGraphicsPolygonItem::Type:
             set_selected_containing_polygon(mode, level_idx, x, y);
             break;
-    
+
           default:
             printf("clicked unhandled type: %d\n",
                 static_cast<int>(graphics_item->type()));

--- a/traffic_editor/include/traffic_editor/rendering_options.h
+++ b/traffic_editor/include/traffic_editor/rendering_options.h
@@ -23,6 +23,8 @@ class RenderingOptions
 public:
   static const int NUM_BUILDING_LANES = 10;
   std::array<bool, NUM_BUILDING_LANES> show_building_lanes;
+
+  bool show_models = true;
 };
 
 #endif


### PR DESCRIPTION
When drawing large maps, sometimes it's helpful to hide all models so that it's easier to read the vertex names of their spawn points.