### PR TITLE
Build fails when dot in path fix

### DIFF
--- a/test_maps/CMakeLists.txt
+++ b/test_maps/CMakeLists.txt
@@ -16,10 +16,8 @@ file(GLOB_RECURSE traffic_editor_paths "maps/*.building.yaml")
 foreach(path ${traffic_editor_paths})
 
   # Get the output world name
-  string(REPLACE "." ";" list1 ${path})
-  list(GET list1 0 name)
-  string(REPLACE "/" ";" list2 ${name})
-  list(GET list2 -1 world_name)
+  string(REGEX REPLACE "\\.[^.]*\.[^.]*$" "" no_extension_path ${path})
+  string(REGEX MATCH "[^\/]+$" world_name  ${no_extension_path})
 
   set(map_path ${path})
   set(output_world_name ${world_name})


### PR DESCRIPTION
The current way of getting the name of he map would fail if there's more than one map and there's a dot in the path to the maps. This will cause future releases with more than one map to fail in the buildfarm. The method to get the map name has been changed to use regex instead.