### PR TITLE
Implement convenience script

### DIFF
--- a/building_map_tools/building_map_model_downloader/__init__.py
+++ b/building_map_tools/building_map_model_downloader/__init__.py
@@ -1,0 +1,1 @@
+from .building_map_model_downloader import *

--- a/building_map_tools/model_downloader/model_downloader.py
+++ b/building_map_tools/model_downloader/model_downloader.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+from building_map_model_downloader import download_models
+import subprocess
+import logging
+import argparse
+import glob
+import os
+
+# Init overall parser
+parser = argparse.ArgumentParser(
+    prog="model_downloader",
+    description="Convenience script to download Fuel models for simulator "
+                "map packages with maps made in traffic_editor. "
+                "(Allows for downloading of  models for all maps in the "
+                "package, or just specific maps.)"
+)
+parser.add_argument("MAP_PACKAGE", type=str,
+                    help="Map package name you want to download from")
+parser.add_argument("-l", "--list", action="store_true",
+                    help="List all available maps in package")
+parser.add_argument("-s", "--select-maps", nargs="+",
+                    help="Specify a subset of maps to download models for")
+parser.add_argument("-m", "--model-path", type=str,
+                    default="~/.gazebo/models/",
+                    help="Path to check models from and download models to")
+parser.add_argument("-c", "--cache", type=str,
+                    default="~/.pit_crew/model_cache.json",
+                    help="Path to pit_crew model cache")
+
+# Init logger
+logger = logging.getLogger(__name__)
+
+
+def main():
+    args = parser.parse_args()
+
+    # OBTAIN PREFIX ==========================================================
+    completed_process = subprocess.run(
+        ["ros2", "pkg", "prefix", args.MAP_PACKAGE], stdout=subprocess.PIPE)
+    prefix = completed_process.stdout.decode('utf-8').strip()
+
+    if completed_process.returncode != 0:
+        logger.error("Package does not exist! Prefix resolution failed!")
+        return
+
+    # GET BUILDING YAML PATHS ================================================
+    # NOTE(CH3): Strongly resisting the urge to hilariously call this map_map
+    map_dict = {
+        os.path.basename(x).replace(".building.yaml", ""): x
+        for x in glob.glob(prefix + "/**/*.building.yaml", recursive=True)
+    }
+
+    if not len(map_dict):
+        logger.error("Package has no maps!")
+        return
+
+    # HANDLE --list ==========================================================
+    if args.list:
+        print(f"Available maps in {args.MAP_PACKAGE}:")
+        for name, path in map_dict.items():
+            print(f"- {name}")
+        return
+
+    # HANDLE --select-maps ===================================================
+    if args.select_maps:
+        selected_maps = []
+
+        for name in args.select_maps:
+            if name in map_dict:
+                selected_maps.append(name)
+            else:
+                logger.warning(f"{name} does not exist in {args.MAP_PACKAGE}! "
+                               "Ignoring!")
+
+    # DOWNLOAD MODELS ========================================================
+    if args.select_maps:  # Download models for selected maps
+        for name in selected_maps:
+            logger.info(f"\n== STARTING: Downloading models for {name} ==\n")
+            download_models(map_dict[name], args.model_path, args.cache)
+            logger.info(f"\n== COMPLETE: Downloaded models for {name} ==\n")
+    else:  # Download models all maps in package
+        for name, yaml_path in map_dict.items():
+            logger.info(f"\n== STARTING: Downloading models for {name} ==\n")
+            download_models(yaml_path, args.model_path, args.cache)
+            logger.info(f"\n== COMPLETE: Downloaded models for {name} ==\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/building_map_tools/model_downloader/model_downloader.py
+++ b/building_map_tools/model_downloader/model_downloader.py
@@ -79,7 +79,7 @@ def main():
             logger.info(f"\n== STARTING: Downloading models for {name} ==\n")
             download_models(map_dict[name], args.model_path, args.cache)
             logger.info(f"\n== COMPLETE: Downloaded models for {name} ==\n")
-    else:  # Download models all maps in package
+    else:  # Download models for all maps in package
         for name, yaml_path in map_dict.items():
             logger.info(f"\n== STARTING: Downloading models for {name} ==\n")
             download_models(yaml_path, args.model_path, args.cache)

--- a/building_map_tools/setup.py
+++ b/building_map_tools/setup.py
@@ -12,6 +12,7 @@ setup(
         'building_map_server',
         'building_map_generator',
         'building_map_model_downloader',
+        'model_downloader',
         'pit_crew'],
     py_modules=[],
     data_files=[
@@ -52,6 +53,8 @@ setup(
             'building_map_generator.building_map_generator:main',
             'building_map_model_downloader = '
             'building_map_model_downloader.building_map_model_downloader:main',
+            'model_downloader = '
+            'model_downloader.model_downloader:main',
         ],
     },
 )


### PR DESCRIPTION
Implements a convenience script for simpler model downloads

## Usage
Simply rebuild `traffic_editor` and invoke:
```shell
$ ros2 run building_map_tools model_downloader -h
```

You can download models for all maps in a specified package by specifying the appropriate map package name.

Also supports listing available maps in the package using the `-l` or `--list` arguments

As well as downloading models for a subset of maps, using the `-s` or `--select-maps` arguments

(Standard `pit_crew` config args are also included. Allowing you to specify the model download directory as well as the pit_crew Fuel model cache.)