### PR TITLE
handle situation when lifts key is not present

### DIFF
--- a/building_map_tools/building_map/building.py
+++ b/building_map_tools/building_map/building.py
@@ -31,14 +31,15 @@ class Building:
         self.transform_all_vertices()
 
         self.lifts = {}
-        for lift_name, lift_yaml in yaml_node['lifts'].items():
-            if 'reference_level_name' in lift_yaml:
-                ref_level_name = lift_yaml['reference_level_name']
-                transform = self.levels[ref_level_name].transform
-            else:
-                transform = self.ref_level.transform
-            self.lifts[lift_name] = \
-                Lift(lift_yaml, lift_name, transform, self.levels)
+        if 'lifts' in yaml_node:
+            for lift_name, lift_yaml in yaml_node['lifts'].items():
+                if 'reference_level_name' in lift_yaml:
+                    ref_level_name = lift_yaml['reference_level_name']
+                    transform = self.levels[ref_level_name].transform
+                else:
+                    transform = self.ref_level.transform
+                self.lifts[lift_name] = \
+                    Lift(lift_yaml, lift_name, transform, self.levels)
 
         self.set_lift_vert_lists()
 


### PR DESCRIPTION
Simple fix to handle buildings without `lifts` key defined.

Fixes #187 