### PR TITLE
simple fix on gui polygon removal and param display

### DIFF
--- a/traffic_editor/gui/building_level.cpp
+++ b/traffic_editor/gui/building_level.cpp
@@ -277,6 +277,13 @@ bool BuildingLevel::delete_selected()
       [](const Fiducial& fiducial) { return fiducial.selected; }),
     fiducials.end());
 
+  polygons.erase(
+    std::remove_if(
+      polygons.begin(),
+      polygons.end(),
+      [](const Polygon& polygon) { return polygon.selected; }),
+    polygons.end());
+
   // Vertices take a lot more care, because we have to check if a vertex
   // is used in an edge or a polygon before deleting it, and update all
   // higher-index vertex indices in the edges and polygon vertex lists.

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -2038,6 +2038,7 @@ void Editor::mouse_add_polygon(
       {
         Polygon polygon;
         polygon.type = polygon_type;
+        polygon.create_required_parameters();
         for (const auto& i : mouse_motion_polygon_vertices)
         {
           polygon.vertices.push_back(i);


### PR DESCRIPTION
Simple fixes
- Was not able to delete polygon after creation, added this delete polygon function
- Floor polygon's param was not displaying on the properties box during initialization. added this