### PR TITLE
fix lifts not cleared when opening another project

### DIFF
--- a/traffic_editor/gui/building.cpp
+++ b/traffic_editor/gui/building.cpp
@@ -107,6 +107,7 @@ bool Building::load_yaml_file()
   for (auto& level : levels)
     level.calculate_scale();
 
+  lifts.clear();
   if (y["lifts"] && y["lifts"].IsMap())
   {
     const YAML::Node& y_lifts = y["lifts"];


### PR DESCRIPTION
So far in the traffic editor, when the user opens another map without closing the current one, the lifts from the previous map would remain on the map (and may be saved to the later opened map as well). So I added a line to clear the lifts before loading the new file. Now this issue should not appear anymore (at least I don't see it on my end after the addition).