### PR TITLE
Fix #198 and naming conventions

### DIFF
--- a/building_sim_plugins/building_gazebo_plugins/CMakeLists.txt
+++ b/building_sim_plugins/building_gazebo_plugins/CMakeLists.txt
@@ -44,44 +44,25 @@ include(GNUInstallDirs)
 
 add_library(slotcar SHARED ${PROJECT_SOURCE_DIR}/src/slotcar.cpp)
 
-target_link_libraries(slotcar
-  PUBLIC
-    # TODO remove eigen
-    Eigen3::Eigen
-    ${building_sim_common_LIBRARIES}
-    ${rmf_fleet_msgs_LIBRARIES}
-    ${rclcpp_LIBRARIES}
-    ${GAZEBO_LIBRARIES}
-    ${gazebo_ros_LIBRARIES}
-    ${geometry_msgs_LIBRARIES}
-    ${tf2_ros_LIBRARIES}
-    ${building_map_msgs_LIBRARIES}
+ament_target_dependencies(slotcar
+  Eigen3
+  building_sim_common
+  rmf_fleet_msgs
+  rclcpp
+  gazebo_ros
+  std_msgs
+  geometry_msgs
+  tf2_ros
+  building_map_msgs
 )
 
 target_include_directories(slotcar
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    ${EIGEN3_INCLUDE_DIRS}
     ${GAZEBO_INCLUDE_DIRS}
-    ${building_sim_common_INCLUDE_DIRS}
-    ${geometry_msgs_INCLUDE_DIRS}
-    ${std_msgs_INCLUDE_DIRS}
-    ${rmf_fleet_msgs_INCLUDE_DIRS}
-    ${building_map_msgs_INCLUDE_DIRS}
-    ${tf2_ros_INCLUDE_DIRS}
-    ${building_map_msgs_INCLUDE_DIRS}
 )
-
-# These lines are taken out because of this issue: https://github.com/ament/ament_cmake/issues/158
-#ament_target_dependencies(slotcar
-#  building_sim_utils
-#  "rmf_fleet_msgs"
-#  "rclcpp"
-#  "gazebo_dev"
-#  "gazebo_ros"
-#  "geometry_msgs"
-#  "tf2_ros"
-#)
 
 ###############################
 # door stuff
@@ -89,14 +70,12 @@ target_include_directories(slotcar
 
 add_library(door SHARED src/door.cpp)
 
-target_link_libraries(door
-  PUBLIC
-    ${building_sim_common_LIBRARIES}
-    ${rmf_fleet_msgs_LIBRARIES}
-    ${rclcpp_LIBRARIES}
-    ${GAZEBO_LIBRARIES}
-    ${gazebo_ros_LIBRARIES}
-    ${rmf_door_msgs_LIBRARIES}
+ament_target_dependencies(door
+  building_sim_common
+  rmf_fleet_msgs
+  rclcpp
+  gazebo_ros
+  rmf_door_msgs
 )
 
 target_include_directories(door
@@ -104,10 +83,6 @@ target_include_directories(door
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     ${GAZEBO_INCLUDE_DIRS}
-    ${building_sim_common_INCLUDE_DIRS}
-    ${gazebo_ros_INCLUDE_DIRS}
-    ${rmf_fleet_msgs_INCLUDE_DIRS}
-    ${rmf_door_msgs_INCLUDE_DIRS}
 )
 
 ###############################
@@ -116,15 +91,13 @@ target_include_directories(door
 
 add_library(lift SHARED src/lift.cpp)
 
-target_link_libraries(lift
-  PUBLIC
-    ${building_sim_common_LIBRARIES}
-    ${rmf_fleet_msgs_LIBRARIES}
-    ${rclcpp_LIBRARIES}
-    ${GAZEBO_LIBRARIES}
-    ${gazebo_ros_LIBRARIES}
-    ${rmf_door_msgs_LIBRARIES}
-    ${rmf_lift_msgs_LIBRARIES}
+ament_target_dependencies(lift
+    building_sim_common
+    rmf_fleet_msgs
+    rclcpp
+    gazebo_ros
+    rmf_door_msgs
+    rmf_lift_msgs
 )
 
 target_include_directories(lift
@@ -132,10 +105,6 @@ target_include_directories(lift
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     ${GAZEBO_INCLUDE_DIRS}
-    ${building_sim_common_INCLUDE_DIRS}
-    ${rmf_fleet_msgs_INCLUDE_DIRS}
-    ${rmf_door_msgs_INCLUDE_DIRS}
-    ${rmf_lift_msgs_INCLUDE_DIRS}
 )
 
 ###############################

--- a/building_sim_plugins/building_plugins_common/CMakeLists.txt
+++ b/building_sim_plugins/building_plugins_common/CMakeLists.txt
@@ -36,15 +36,15 @@ include(GNUInstallDirs)
 
 add_library(slotcar_common SHARED ${PROJECT_SOURCE_DIR}/src/slotcar_common.cpp)
 
-target_link_libraries(slotcar_common
-  PUBLIC
-    Eigen3::Eigen
-    ${rmf_fleet_msgs_LIBRARIES}
-    ${building_map_msgs_LIBRARIES}
-    ${rclcpp_LIBRARIES}
-    ${geometry_msgs_LIBRARIES}
-    ${tf2_ros_LIBRARIES}
+ament_target_dependencies(slotcar_common
+    Eigen3
+    rmf_fleet_msgs
+    building_map_msgs
+    rclcpp
+    geometry_msgs
+    tf2_ros
 )
+
 
 target_include_directories(slotcar_common
   PUBLIC
@@ -65,11 +65,10 @@ target_include_directories(slotcar_common
 
 add_library(door_common SHARED src/door_common.cpp)
 
-target_link_libraries(door_common
- PUBLIC
-   ${rmf_fleet_msgs_LIBRARIES}
-   ${rclcpp_LIBRARIES}
-   ${rmf_door_msgs_LIBRARIES}
+ament_target_dependencies(door_common
+    rmf_fleet_msgs
+    rclcpp
+    rmf_door_msgs
 )
 
 target_include_directories(door_common
@@ -86,13 +85,13 @@ target_include_directories(door_common
 
 add_library(lift_common SHARED src/lift_common.cpp)
 
-target_link_libraries(lift_common
- PUBLIC
-   ${rmf_fleet_msgs_LIBRARIES}
-   ${rclcpp_LIBRARIES}
-   ${rmf_door_msgs_LIBRARIES}
-   ${rmf_lift_msgs_LIBRARIES}
+ament_target_dependencies(lift_common
+   rmf_fleet_msgs
+   rclcpp
+   rmf_door_msgs
+   rmf_lift_msgs
 )
+
 
 target_include_directories(lift_common
  PUBLIC

--- a/building_sim_plugins/building_plugins_common/CMakeLists.txt
+++ b/building_sim_plugins/building_plugins_common/CMakeLists.txt
@@ -41,6 +41,7 @@ ament_target_dependencies(slotcar_common
     rmf_fleet_msgs
     building_map_msgs
     rclcpp
+    std_msgs
     geometry_msgs
     tf2_ros
 )
@@ -52,11 +53,6 @@ target_include_directories(slotcar_common
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     ${EIGEN3_INCLUDE_DIRS}
     ${GAZEBO_INCLUDE_DIRS}
-    ${geometry_msgs_INCLUDE_DIRS}
-    ${std_msgs_INCLUDE_DIRS}
-    ${rmf_fleet_msgs_INCLUDE_DIRS}
-    ${building_map_msgs_INCLUDE_DIRS}
-    ${tf2_ros_INCLUDE_DIRS}
 )
 
 ###############################
@@ -75,8 +71,6 @@ target_include_directories(door_common
  PUBLIC
    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-   ${rmf_fleet_msgs_INCLUDE_DIRS}
-   ${rmf_door_msgs_INCLUDE_DIRS}
 )
 
 ###############################
@@ -97,9 +91,6 @@ target_include_directories(lift_common
  PUBLIC
    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-   ${rmf_fleet_msgs_INCLUDE_DIRS}
-   ${rmf_door_msgs_INCLUDE_DIRS}
-   ${rmf_lift_msgs_INCLUDE_DIRS}
 )
 
 ###############################

--- a/building_sim_plugins/building_plugins_common/package.xml
+++ b/building_sim_plugins/building_plugins_common/package.xml
@@ -15,6 +15,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>eigen</build_depend>
+
   <depend>rclcpp</depend>
   <depend>rmf_fleet_msgs</depend>
   <depend>rmf_door_msgs</depend>


### PR DESCRIPTION
This PR is aimed to fix the build errors as specified in https://github.com/osrf/traffic_editor/issues/198. 

There is an additional issue that seems to present, the name for the package `building_sim_common` does not correspond to the folder it is in: `building_plugin_common`: https://github.com/osrf/traffic_editor/blob/master/building_sim_plugins/building_plugins_common/CMakeLists.txt

This naming convention should be unified, but i'm wondering which name to follow: `plugin` or `sim`.