### PR TITLE
fix initial model angle, so it doesn't rotate 90 degrees when placed

### DIFF
--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -1842,7 +1842,7 @@ void Editor::mouse_add_model(
       p.x(),
       p.y(),
       0.0,
-      0.0,
+      M_PI / 2.0,
       mouse_motion_editor_model->name);
     /*
     const int model_row = model_name_list_widget->currentRow();


### PR DESCRIPTION
Trivial code change. As you moved the mouse around to place a model, it was rendering +90 degrees from what it would appear after you clicked the mouse. Now it doesn't. Thanks @MakinoharaShouko for pointing this out!