### PR TITLE
Fixing lift doors not updated after renaming the levels

### DIFF
--- a/traffic_editor/gui/building_level_dialog.cpp
+++ b/traffic_editor/gui/building_level_dialog.cpp
@@ -19,7 +19,7 @@
 #include <QtWidgets>
 
 
-BuildingLevelDialog::BuildingLevelDialog(BuildingLevel& _level, Building* _building)
+BuildingLevelDialog::BuildingLevelDialog(BuildingLevel& _level, Building& _building)
 : building_level(_level), building(_building)
 {
   ok_button = new QPushButton("OK", this);  // first button = [enter] button
@@ -182,10 +182,10 @@ void BuildingLevelDialog::ok_button_clicked()
   }
   auto original_name = building_level.name;
   building_level.name = name_line_edit->text().toStdString();
-  for (size_t i = 0; i < building->lifts.size(); i ++) {
-    if (building->lifts[i].level_doors.find(original_name) != building->lifts[i].level_doors.end()) {
-      building->lifts[i].level_doors[building_level.name] = building->lifts[i].level_doors[original_name];
-      building->lifts[i].level_doors.erase(original_name);
+  for (size_t i = 0; i < building.lifts.size(); i ++) {
+    if (building.lifts[i].level_doors.find(original_name) != building.lifts[i].level_doors.end()) {
+      building.lifts[i].level_doors[building_level.name] = building.lifts[i].level_doors[original_name];
+      building.lifts[i].level_doors.erase(original_name);
     }
   }
   building_level.elevation = elevation_line_edit->text().toDouble();

--- a/traffic_editor/gui/building_level_dialog.cpp
+++ b/traffic_editor/gui/building_level_dialog.cpp
@@ -184,11 +184,7 @@ void BuildingLevelDialog::ok_button_clicked()
   building_level.name = name_line_edit->text().toStdString();
   for (size_t i = 0; i < building->lifts.size(); i ++) {
     if (building->lifts[i].level_doors.find(original_name) != building->lifts[i].level_doors.end()) {
-      while (!building->lifts[i].level_doors[original_name].empty()) {
-        auto str = building->lifts[i].level_doors[original_name].front();
-        building->lifts[i].level_doors[original_name].pop_front();
-        building->lifts[i].level_doors[building_level.name].push_back(str);
-      }
+      building->lifts[i].level_doors[building_level.name] = building->lifts[i].level_doors[original_name];
       building->lifts[i].level_doors.erase(original_name);
     }
   }

--- a/traffic_editor/gui/building_level_dialog.cpp
+++ b/traffic_editor/gui/building_level_dialog.cpp
@@ -19,8 +19,8 @@
 #include <QtWidgets>
 
 
-BuildingLevelDialog::BuildingLevelDialog(BuildingLevel& _level)
-: building_level(_level)
+BuildingLevelDialog::BuildingLevelDialog(BuildingLevel& _level, Building* _building)
+: building_level(_level), building(_building)
 {
   ok_button = new QPushButton("OK", this);  // first button = [enter] button
   cancel_button = new QPushButton("Cancel", this);
@@ -180,7 +180,18 @@ void BuildingLevelDialog::ok_button_clicked()
       "Name must not be empty");
     return;
   }
+  auto original_name = building_level.name;
   building_level.name = name_line_edit->text().toStdString();
+  for (size_t i = 0; i < building->lifts.size(); i ++) {
+    if (building->lifts[i].level_doors.find(original_name) != building->lifts[i].level_doors.end()) {
+      while (!building->lifts[i].level_doors[original_name].empty()) {
+        auto str = building->lifts[i].level_doors[original_name].front();
+        building->lifts[i].level_doors[original_name].pop_front();
+        building->lifts[i].level_doors[building_level.name].push_back(str);
+      }
+      building->lifts[i].level_doors.erase(original_name);
+    }
+  }
   building_level.elevation = elevation_line_edit->text().toDouble();
   building_level.drawing_filename =
     drawing_filename_line_edit->text().toStdString();

--- a/traffic_editor/gui/building_level_dialog.h
+++ b/traffic_editor/gui/building_level_dialog.h
@@ -19,7 +19,6 @@
 #define BUILDING_LEVEL_DIALOG_H
 
 #include <QDialog>
-#include <string>
 #include "traffic_editor/building.h"
 #include "traffic_editor/building_level.h"
 class QLineEdit;

--- a/traffic_editor/gui/building_level_dialog.h
+++ b/traffic_editor/gui/building_level_dialog.h
@@ -27,12 +27,12 @@ class QLineEdit;
 class BuildingLevelDialog : public QDialog
 {
 public:
-  BuildingLevelDialog(BuildingLevel& level, Building* building);
+  BuildingLevelDialog(BuildingLevel& level, Building& building);
   ~BuildingLevelDialog();
 
 private:
   BuildingLevel& building_level;
-  Building* building;
+  Building& building;
 
   QLineEdit* name_line_edit, * drawing_filename_line_edit;
   QLineEdit* x_line_edit, * y_line_edit;

--- a/traffic_editor/gui/building_level_dialog.h
+++ b/traffic_editor/gui/building_level_dialog.h
@@ -19,6 +19,8 @@
 #define BUILDING_LEVEL_DIALOG_H
 
 #include <QDialog>
+#include <string>
+#include "traffic_editor/building.h"
 #include "traffic_editor/building_level.h"
 class QLineEdit;
 
@@ -26,11 +28,12 @@ class QLineEdit;
 class BuildingLevelDialog : public QDialog
 {
 public:
-  BuildingLevelDialog(BuildingLevel& level);
+  BuildingLevelDialog(BuildingLevel& level, Building* building);
   ~BuildingLevelDialog();
 
 private:
   BuildingLevel& building_level;
+  Building* building;
 
   QLineEdit* name_line_edit, * drawing_filename_line_edit;
   QLineEdit* x_line_edit, * y_line_edit;

--- a/traffic_editor/gui/building_level_table.cpp
+++ b/traffic_editor/gui/building_level_table.cpp
@@ -76,7 +76,7 @@ void BuildingLevelTable::update(Building& building)
       &QAbstractButton::clicked,
       [this, &building, i]()
       {
-        BuildingLevelDialog level_dialog(building.levels[i]);
+        BuildingLevelDialog level_dialog(building.levels[i], &building);
         if (level_dialog.exec() == QDialog::Accepted)
         {
           building.levels[i].load_drawing();
@@ -99,7 +99,7 @@ void BuildingLevelTable::update(Building& building)
     [this, &building]()
     {
       BuildingLevel level;
-      BuildingLevelDialog level_dialog(level);
+      BuildingLevelDialog level_dialog(level, &building);
       if (level_dialog.exec() == QDialog::Accepted)
       {
         level.load_drawing();

--- a/traffic_editor/gui/building_level_table.cpp
+++ b/traffic_editor/gui/building_level_table.cpp
@@ -76,7 +76,7 @@ void BuildingLevelTable::update(Building& building)
       &QAbstractButton::clicked,
       [this, &building, i]()
       {
-        BuildingLevelDialog level_dialog(building.levels[i], &building);
+        BuildingLevelDialog level_dialog(building.levels[i], building);
         if (level_dialog.exec() == QDialog::Accepted)
         {
           building.levels[i].load_drawing();
@@ -99,7 +99,7 @@ void BuildingLevelTable::update(Building& building)
     [this, &building]()
     {
       BuildingLevel level;
-      BuildingLevelDialog level_dialog(level, &building);
+      BuildingLevelDialog level_dialog(level, building);
       if (level_dialog.exec() == QDialog::Accepted)
       {
         level.load_drawing();


### PR DESCRIPTION
In the current traffic editor, when the user renames a building level, the lift doors do not update and the lift doors on the old levels still remain in the .building.yaml file. This update should fix this problem. I have tested on my own computer and everything looks fine.