### PR TITLE
Use door name in plugin name to prevent node name clashes

### DIFF
--- a/building_map_tools/building_map/doors/double_sliding_door.py
+++ b/building_map_tools/building_map/doors/double_sliding_door.py
@@ -22,7 +22,7 @@ class DoubleSlidingDoor(Door):
             options)
 
         plugin_ele = SubElement(self.model_ele, 'plugin')
-        plugin_ele.set('name', 'door')
+        plugin_ele.set('name', f'door_{self.name}')
         plugin_ele.set('filename', 'libdoor.so')
         plugin_params = {
           'v_max_door': '0.2',

--- a/building_map_tools/building_map/doors/double_swing_door.py
+++ b/building_map_tools/building_map/doors/double_swing_door.py
@@ -32,7 +32,7 @@ class DoubleSwingDoor(Door):
             options)
 
         plugin_ele = SubElement(self.model_ele, 'plugin')
-        plugin_ele.set('name', 'door')
+        plugin_ele.set('name', f'door_{self.name}')
         plugin_ele.set('filename', 'libdoor.so')
         plugin_params = {
           'v_max_door': '0.5',

--- a/building_map_tools/building_map/doors/sliding_door.py
+++ b/building_map_tools/building_map/doors/sliding_door.py
@@ -15,7 +15,7 @@ class SlidingDoor(Door):
             options)
 
         plugin_ele = SubElement(self.model_ele, 'plugin')
-        plugin_ele.set('name', 'door')
+        plugin_ele.set('name', f'door_{self.name}')
         plugin_ele.set('filename', 'libdoor.so')
         plugin_params = {
           'v_max_door': '0.2',

--- a/building_map_tools/building_map/doors/swing_door.py
+++ b/building_map_tools/building_map/doors/swing_door.py
@@ -11,7 +11,7 @@ class SwingDoor(Door):
 
     def generate(self, world_ele, options):
         plugin_ele = SubElement(self.model_ele, 'plugin')
-        plugin_ele.set('name', 'door')
+        plugin_ele.set('name', f'door_{self.name}')
         plugin_ele.set('filename', 'libdoor.so')
         plugin_params = {
           'v_max_door': '0.5',

--- a/building_map_tools/building_map/lift.py
+++ b/building_map_tools/building_map/lift.py
@@ -184,7 +184,7 @@ class LiftDoor:
                                     upper_limit=0))
 
         plugin_ele = SubElement(lift_model_ele, 'plugin')
-        plugin_ele.set('name', 'door')
+        plugin_ele.set('name', f'door_{name}')
         plugin_ele.set('filename', 'libdoor.so')
         for param_name, param_value in self.params.items():
             ele = SubElement(plugin_ele, param_name)

--- a/building_map_tools/building_map/lift.py
+++ b/building_map_tools/building_map/lift.py
@@ -124,7 +124,7 @@ class LiftDoor:
 
     def generate_door_plugin(self, model_ele, name):
         plugin_ele = SubElement(model_ele, 'plugin')
-        plugin_ele.set('name', 'door')
+        plugin_ele.set('name', f'door_{name}')
         plugin_ele.set('filename', 'libdoor.so')
         for param_name, param_value in self.params.items():
             ele = SubElement(plugin_ele, param_name)


### PR DESCRIPTION
`gazebo_ros` creates nodes using the `name` value of the `plugin` element. This PR makes the SDF generator use the name of a door in its plugin name to prevent node name clashes when more than one door is present in the world.

Signed-off-by: Geoffrey Biggs <gbiggs@killbots.net>