### PR TITLE
Fixing model elevations not change & lift doors erased by mistake

### DIFF
--- a/traffic_editor/gui/building_level_dialog.cpp
+++ b/traffic_editor/gui/building_level_dialog.cpp
@@ -197,10 +197,6 @@ void BuildingLevelDialog::ok_button_clicked()
     }
   }
   building_level.elevation = elevation_line_edit->text().toDouble();
-  for (size_t i = 0; i < building_level.models.size(); i ++)
-  {
-    building_level.models[i].state.z = building_level.elevation;
-  }
   building_level.drawing_filename =
     drawing_filename_line_edit->text().toStdString();
   if (building_level.drawing_filename.empty())

--- a/traffic_editor/gui/building_level_dialog.cpp
+++ b/traffic_editor/gui/building_level_dialog.cpp
@@ -183,14 +183,17 @@ void BuildingLevelDialog::ok_button_clicked()
   }
   auto original_name = building_level.name;
   building_level.name = name_line_edit->text().toStdString();
-  for (size_t i = 0; i < building.lifts.size(); i ++)
+  if (original_name != building_level.name)
   {
-    if (building.lifts[i].level_doors.find(original_name) !=
-      building.lifts[i].level_doors.end())
+    for (size_t i = 0; i < building.lifts.size(); i ++)
     {
-      building.lifts[i].level_doors[building_level.name] =
-        building.lifts[i].level_doors[original_name];
-      building.lifts[i].level_doors.erase(original_name);
+      if (building.lifts[i].level_doors.find(original_name) !=
+        building.lifts[i].level_doors.end())
+      {
+        building.lifts[i].level_doors[building_level.name] =
+          building.lifts[i].level_doors[original_name];
+        building.lifts[i].level_doors.erase(original_name);
+      }
     }
   }
   building_level.elevation = elevation_line_edit->text().toDouble();

--- a/traffic_editor/gui/building_level_dialog.cpp
+++ b/traffic_editor/gui/building_level_dialog.cpp
@@ -194,6 +194,10 @@ void BuildingLevelDialog::ok_button_clicked()
     }
   }
   building_level.elevation = elevation_line_edit->text().toDouble();
+  for (size_t i = 0; i < building_level.models.size(); i ++)
+  {
+    building_level.models[i].state.z = building_level.elevation;
+  }
   building_level.drawing_filename =
     drawing_filename_line_edit->text().toStdString();
   if (building_level.drawing_filename.empty())


### PR DESCRIPTION
When the building level changes, the model elevation did not change, this update fixes that.

Additionally, in [my last pull request](https://github.com/osrf/traffic_editor/pull/203), though the lift doors are updated as the level name changes, it would also remove the doors when the level name is not modified. The update also fixes that bug.