### PR TITLE
generate models at the correct Z height of their level

### DIFF
--- a/building_map_tools/building_map/level.py
+++ b/building_map_tools/building_map/level.py
@@ -156,7 +156,11 @@ class Level:
         model_cnt = 0
         for model in self.models:
             model_cnt += 1
-            model.generate(world_ele, model_cnt, self.transform, self.elevation)
+            model.generate(
+                world_ele,
+                model_cnt,
+                self.transform,
+                self.elevation)
 
         # sniff around in our vertices and spawn robots if requested
         for vertex_idx, vertex in enumerate(self.vertices):

--- a/building_map_tools/building_map/level.py
+++ b/building_map_tools/building_map/level.py
@@ -156,7 +156,7 @@ class Level:
         model_cnt = 0
         for model in self.models:
             model_cnt += 1
-            model.generate(world_ele, model_cnt, self.transform)
+            model.generate(world_ele, model_cnt, self.transform, self.elevation)
 
         # sniff around in our vertices and spawn robots if requested
         for vertex_idx, vertex in enumerate(self.vertices):

--- a/building_map_tools/building_map/model.py
+++ b/building_map_tools/building_map/model.py
@@ -30,7 +30,7 @@ class Model:
 
         self.yaw = yaml_node['yaw']
 
-    def generate(self, world_ele, model_cnt, transform):
+    def generate(self, world_ele, model_cnt, transform, elevation):
         include_ele = SubElement(world_ele, 'include')
         name_ele = SubElement(include_ele, 'name')
         name_ele.text = self.name
@@ -38,7 +38,7 @@ class Model:
         uri_ele.text = f'model://{self.model_name}'
         pose_ele = SubElement(include_ele, 'pose')
         x, y = transform.transform_point((self.x, self.y))
-        z = self.z
+        z = self.z + elevation
         yaw = self.yaw + transform.rotation
         pose_ele.text = f'{x} {y} {z} 0 0 {yaw}'
 


### PR DESCRIPTION
The intent of the `z` parameter in a model in `traffic-editor` was to specify "height above the floor", for example, an item on a simulated countertop would be `z=1.0`. Then, the `building_map_generator` would stack things appropriately. Unfortunately, `building_map_generator` was ignoring the height of the level, and just copying `model.z` into the simulation world's instance of the model. This PR should fix that, so that the elevation of the building level of each model is used as intended.