### PR TITLE
update top level readme installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,9 @@ This repository has the following directories:
 
 # Installation
 
-The GUI of `traffic-editor` can be installed and used independently from ROS 2
-if desired. This process is documented in the `traffic_editor` package README.
-However, building with `colcon` as part of a ROS 2 workspace allows easier
-generation and use of Gazebo simulation worlds from `traffic-editor` buildings.
-The `building_map_tools` package requires the following Python 3 dependencies
-to generate worlds:
+This repository is structed as a collection of ROS 2 packages and can be built using `colcon`.
+
+The `building_map_tools` package requires the following Python 3 dependencies to generate worlds:
 
 ```
 sudo apt install python3-shapely python3-yaml python3-requests


### PR DESCRIPTION
I believe that since the GUI now has some ROS 2 dependencies, it needs to be built using `colcon`. This PR removes the text that previously said it could be built independently using "normal" standalone CMake.