### PR TITLE
added inertia for lift cabin platform

### DIFF
--- a/building_map_tools/building_map/lift.py
+++ b/building_map_tools/building_map/lift.py
@@ -215,7 +215,7 @@ class Lift:
         self.shaft_width = self.width + 2 * self.gap
 
         # default params
-        self.cabin_mass = 800
+        self.cabin_mass = 1200
         self.params = {
             'v_max_cabin': 2.0,
             'a_max_cabin': 1.2,
@@ -316,6 +316,13 @@ class Lift:
         inertial = SubElement(platform, 'inertial')
         mass = SubElement(inertial, 'mass')
         mass.text = f'{self.cabin_mass}'
+        inertial = SubElement(inertial, 'inertia')
+        SubElement(inertial, 'ixx').text = \
+            str(self.cabin_mass/12.0*(self.width**2 + self.floor_thickness**2))
+        SubElement(inertial, 'iyy').text = \
+            str(self.cabin_mass/12.0*(self.depth**2 + self.floor_thickness**2))
+        SubElement(inertial, 'izz').text = \
+            str(self.cabin_mass/12.0*(self.width**2 + self.depth**2))
 
         # visuals and collisions for floor and walls of cabin
         floor_dims = [self.width, self.depth, self.floor_thickness]


### PR DESCRIPTION
Addressing [this](https://answers.gazebosim.org/question/25677/prismatic-joint-for-lift-door-having-strange-behaviors-when-its-parent-lift-model-is-loaded-with-heavy-robots/) issue related to the lift's cabin door.

This seems to be an issue related to the missing moment of inertia of the lift cabin. When the simulated robot moves into the lift, the stopping position in the lift cabin is slightly off-centred. This resulted in slightly tilting the lift cabin, affecting the motion of the cabin door. (just my rough assumption)

Added inertia and tested it on my machine. Now the cabin door works fine. :tada: 