### PR TITLE
Improve lift initial floor definition

### DIFF
--- a/building_map_tools/building_map/building.py
+++ b/building_map_tools/building_map/building.py
@@ -216,6 +216,9 @@ class Building:
             pose_ele.text = f'0 0 {level.elevation} 0 0 0'
 
         for lift_name, lift in self.lifts.items():
+            if not lift.level_doors:
+                print(f'[{lift_name}] is not serving any floor, ignoring.')
+                continue
             lift.generate_shaft_doors(world)
             lift.generate_cabin(world, options)
 

--- a/building_map_tools/building_map/level.py
+++ b/building_map_tools/building_map/level.py
@@ -103,7 +103,8 @@ class Level:
 
     def set_lift_vert_lists(self, lift_vert_lists, lifts):
         for lift_name, lift in lifts.items():
-            if self.elevation >= lift.lowest_elevation and \
+            if lift.level_doors and \
+                    self.elevation >= lift.lowest_elevation and \
                     self.elevation <= lift.highest_elevation:
                 self.lift_vert_lists[lift_name] = \
                     (lift_vert_lists[lift_name])

--- a/building_map_tools/building_map/lift.py
+++ b/building_map_tools/building_map/lift.py
@@ -201,10 +201,15 @@ class Lift:
         self.name = name
         print(f'parsing lift {name}')
 
-        self.initial_floor_name = yaml_node['initial_floor_name']
         self.depth = float(yaml_node['depth'])
         self.width = float(yaml_node['width'])
         self.yaw = float(yaml_node['yaw'])
+
+        if 'initial_floor_name' in yaml_node:
+            self.initial_floor_name = str(yaml_node['initial_floor_name'])
+        else:
+            self.initial_floor_name = ''
+
         if 'highest_floor' in yaml_node:
             self.highest_floor = str(yaml_node['highest_floor'])
             if self.highest_floor:
@@ -249,6 +254,9 @@ class Lift:
                 self.level_doors[level_name] = door_names
                 self.level_elevation[level_name] = levels[level_name].elevation
                 self.level_names.append(level_name)
+
+        if (not self.initial_floor_name) and self.level_names:
+            self.initial_floor_name = self.level_names[0]
 
         self.doors = []
         if 'doors' in yaml_node:

--- a/building_map_tools/building_map/lift.py
+++ b/building_map_tools/building_map/lift.py
@@ -201,7 +201,7 @@ class Lift:
         self.name = name
         print(f'parsing lift {name}')
 
-        self.reference_floor_name = yaml_node['reference_floor_name']
+        self.initial_floor_name = yaml_node['initial_floor_name']
         self.depth = float(yaml_node['depth'])
         self.width = float(yaml_node['width'])
         self.yaw = float(yaml_node['yaw'])
@@ -387,8 +387,8 @@ class Lift:
                         'shaft_door',
                         f'ShaftDoor_{self.name}_{level_name}_{door.name}')
 
-        reference_floor_ele = SubElement(plugin_ele, 'reference_floor')
-        reference_floor_ele.text = f'{self.reference_floor_name}'
+        initial_floor_ele = SubElement(plugin_ele, 'initial_floor')
+        initial_floor_ele.text = f'{self.initial_floor_name}'
         for param_name, param_value in self.params.items():
             ele = SubElement(plugin_ele, param_name)
             ele.text = f'{param_value}'

--- a/building_sim_plugins/building_gazebo_plugins/src/lift.cpp
+++ b/building_sim_plugins/building_gazebo_plugins/src/lift.cpp
@@ -63,11 +63,11 @@ public:
     _update_connection = gazebo::event::Events::ConnectWorldUpdateBegin(
       std::bind(&LiftPlugin::on_update, this));
 
+    _cabin_joint_ptr->SetPosition(0, _lift_common->get_elevation());
+
     RCLCPP_INFO(_ros_node->get_logger(),
       "Finished loading [%s]",
       _model->GetName().c_str());
-
-    _cabin_joint_ptr->SetPosition(0, _lift_common->get_elevation());
 
     _initialized = true;
   }

--- a/building_sim_plugins/building_plugins_common/include/building_sim_common/lift_common.hpp
+++ b/building_sim_plugins/building_plugins_common/include/building_sim_common/lift_common.hpp
@@ -112,7 +112,7 @@ private:
       std::string, std::vector<std::string>> floor_name_to_cabin_door_name,
     std::unordered_map<std::string, DoorState::SharedPtr> shaft_door_states,
     std::unordered_map<std::string, DoorState::SharedPtr> cabin_door_states,
-    const std::string reference_floor_name);
+    std::string initial_floor_name);
 
   double get_step_velocity(const double dt, const double position,
     const double velocity);
@@ -228,9 +228,19 @@ std::unique_ptr<LiftCommon> LiftCommon::make(
   }
 
   assert(!floor_names.empty());
-  std::string& reference_floor_name = floor_names[0];
-  get_sdf_param_if_available<std::string>(sdf_clone, "reference_floor",
-    reference_floor_name);
+  std::string initial_floor_name = floor_names[0];
+  get_sdf_param_if_available<std::string>(sdf_clone, "initial_floor",
+    initial_floor_name);
+
+  if (std::find(floor_names.begin(), floor_names.end(), initial_floor_name) ==
+    floor_names.end())
+  {
+    RCLCPP_WARN(
+      node->get_logger(),
+      "Initial floor [%s] is not available, changing to deafult",
+      initial_floor_name.c_str());
+    initial_floor_name = floor_names[0];
+  }
 
   std::unique_ptr<LiftCommon> lift(new LiftCommon(
       node,
@@ -243,7 +253,7 @@ std::unique_ptr<LiftCommon> LiftCommon::make(
       floor_name_to_cabin_door_name,
       shaft_door_states,
       cabin_door_states,
-      reference_floor_name));
+      initial_floor_name));
 
   return lift;
 }

--- a/building_sim_plugins/building_plugins_common/src/lift_common.cpp
+++ b/building_sim_plugins/building_plugins_common/src/lift_common.cpp
@@ -52,8 +52,7 @@ void LiftCommon::publish_door_request(const double time, std::string door_name,
 double LiftCommon::get_step_velocity(const double dt, const double position,
   const double velocity)
 {
-  double desired_elevation =
-    _floor_name_to_elevation[_lift_state.destination_floor];
+  double desired_elevation = get_elevation();
   double dz = desired_elevation - position;
 
   if (abs(dz) < _cabin_motion_params.dx_min / 2.0)
@@ -177,7 +176,7 @@ LiftCommon::LiftCommon(rclcpp::Node::SharedPtr node,
     std::string, std::vector<std::string>> floor_name_to_cabin_door_name,
   std::unordered_map<std::string, DoorState::SharedPtr> shaft_door_states,
   std::unordered_map<std::string, DoorState::SharedPtr> cabin_door_states,
-  const std::string reference_floor_name)
+  std::string initial_floor_name)
 : _ros_node(node),
   _lift_name(lift_name),
   _cabin_joint_name(joint_name),
@@ -246,7 +245,7 @@ LiftCommon::LiftCommon(rclcpp::Node::SharedPtr node,
   // Initial lift state
   _lift_state.lift_name = _lift_name;
   _lift_state.current_floor = _floor_names[0];
-  _lift_state.destination_floor = reference_floor_name;
+  _lift_state.destination_floor = initial_floor_name;
   _lift_state.door_state = LiftState::DOOR_CLOSED;
   _lift_state.motion_state = LiftState::MOTION_STOPPED;
   for (const std::string& floor_name : _floor_names)

--- a/traffic_editor/gui/lift.cpp
+++ b/traffic_editor/gui/lift.cpp
@@ -38,6 +38,10 @@ void Lift::from_yaml(const std::string& _name, const YAML::Node& data)
   yaw = data["yaw"].as<double>();
   name = _name;
   reference_floor_name = data["reference_floor_name"].as<string>();
+  if (data["initial_floor_name"])
+    initial_floor_name = data["initial_floor_name"].as<string>();
+  else
+    initial_floor_name = reference_floor_name;
   width = data["width"].as<double>();
   depth = data["depth"].as<double>();
 
@@ -83,6 +87,7 @@ YAML::Node Lift::to_yaml() const
   // let's give yaw another decimal place because, I don't know, reasons (?)
   n["yaw"] = std::round(yaw * 10000.0) / 10000.0;
   n["reference_floor_name"] = reference_floor_name;
+  n["initial_floor_name"] = initial_floor_name;
   n["width"] = std::round(width * 1000.0) / 1000.0;
   n["depth"] = std::round(depth * 1000.0) / 1000.0;
 

--- a/traffic_editor/gui/lift_dialog.cpp
+++ b/traffic_editor/gui/lift_dialog.cpp
@@ -76,6 +76,23 @@ LiftDialog::LiftDialog(Lift& lift, Building& building)
     });
   ref_name_hbox->addWidget(_reference_floor_combo_box);
 
+  QHBoxLayout* init_floor_hbox = new QHBoxLayout;
+  init_floor_hbox->addWidget(new QLabel("Initial floor:"));
+  _initial_floor_combo_box = new QComboBox;
+  for (const QString& level_name : _level_names)
+    _initial_floor_combo_box->addItem(level_name);
+  _initial_floor_combo_box->setCurrentText(
+    QString::fromStdString(_lift.initial_floor_name));
+  connect(
+    _initial_floor_combo_box,
+    &QComboBox::currentTextChanged,
+    [this](const QString& text)
+    {
+      _lift.initial_floor_name = text.toStdString();
+      emit redraw();
+    });
+  init_floor_hbox->addWidget(_initial_floor_combo_box);
+
   QHBoxLayout* x_hbox = new QHBoxLayout;
   x_hbox->addWidget(new QLabel("X:"));
   _x_line_edit =
@@ -203,6 +220,7 @@ LiftDialog::LiftDialog(Lift& lift, Building& building)
   QVBoxLayout* left_vbox = new QVBoxLayout;
   left_vbox->addLayout(name_hbox);
   left_vbox->addLayout(ref_name_hbox);
+  left_vbox->addLayout(init_floor_hbox);
   left_vbox->addLayout(x_hbox);
   left_vbox->addLayout(y_hbox);
   left_vbox->addLayout(yaw_hbox);

--- a/traffic_editor/gui/lift_dialog.h
+++ b/traffic_editor/gui/lift_dialog.h
@@ -48,6 +48,7 @@ private:
 
   QLineEdit* _name_line_edit;
   QComboBox* _reference_floor_combo_box;
+  QComboBox* _initial_floor_combo_box;
   QLineEdit* _x_line_edit;
   QLineEdit* _y_line_edit;
   QLineEdit* _yaw_line_edit;

--- a/traffic_editor/include/traffic_editor/lift.h
+++ b/traffic_editor/include/traffic_editor/lift.h
@@ -37,6 +37,7 @@ class Lift
 public:
   std::string name;
   std::string reference_floor_name;
+  std::string initial_floor_name;
 
   // (x, y, yaw) of the cabin center, relative to reference_floor_name origin
   double x = 0.0;


### PR DESCRIPTION
This PR includes the following features:
- Adding a field in the lift dialog of traffic_editor GUI to specify the initial floor of the lift
- When the initial floor is not being served by the lift, the lift will be generated on the first floor instead
- If a lift is not serving any floor (i.e. having no doors open on any floor), the lift model will not be generated.

I am making this a draft PR, for now, to avoid conflicts with https://github.com/osrf/traffic_editor/pull/220. Once that is merged, I might change the lift shaft holes generation when lift model is not generated accordingly.