### PR TITLE
Update lift session id in lift plugin

### DIFF
--- a/building_sim_plugins/building_plugins_common/include/building_sim_common/lift_common.hpp
+++ b/building_sim_plugins/building_plugins_common/include/building_sim_common/lift_common.hpp
@@ -228,7 +228,7 @@ std::unique_ptr<LiftCommon> LiftCommon::make(
   }
 
   assert(!floor_names.empty());
-  std::string& reference_floor_name = floor_names[0];
+  std::string reference_floor_name = floor_names[0];
   get_sdf_param_if_available<std::string>(sdf_clone, "reference_floor",
     reference_floor_name);
 

--- a/building_sim_plugins/building_plugins_common/src/lift_common.cpp
+++ b/building_sim_plugins/building_plugins_common/src/lift_common.cpp
@@ -284,6 +284,10 @@ LiftCommon::LiftUpdateResult LiftCommon::update(const double time,
   {
     std::string desired_floor = _lift_request->destination_floor;
     uint8_t desired_door_state = _lift_request->door_state;
+    if (_lift_request->request_type == LiftRequest::REQUEST_END_SESSION)
+      _lift_state.session_id = "";
+    else
+      _lift_state.session_id = _lift_request->session_id;
 
     if ((_lift_state.current_floor == desired_floor) &&
       (_lift_state.door_state == desired_door_state) &&


### PR DESCRIPTION
This PR updates lift `session_id` in the `lift_state` message each lift plugin stores and publishes. This is required for the new features in `rmf_core` to make robots check the `session_id` before entering the lift.

Additionally, a minor bug in `available_floors` displayed in `lift_state` messages is fixed.