### PR TITLE
Implement model visibility toggling

### DIFF
--- a/building_map_tools/building_map/building.py
+++ b/building_map_tools/building_map/building.py
@@ -253,6 +253,16 @@ class Building:
                         'model',
                         {'name': door.params['name'].value})
 
+                for lift_name, lift in self.lifts.items():
+                    if level_name in lift.level_doors:
+                        for door in lift.doors:
+                            if door.name in lift.level_doors[level_name]:
+                                model_ele = SubElement(
+                                    floor_ele,
+                                    'model',
+                                    {'name':(f'ShaftDoor_{lift_name}_' + \
+                                        f'{level_name}_{door.name}')})
+
         elif 'ignition' in options:
             plugin_ele = gui_ele.find('.//plugin[@filename="GzScene3D"]')
             camera_pose_ele = plugin_ele.find('camera_pose')

--- a/building_map_tools/building_map/building.py
+++ b/building_map_tools/building_map/building.py
@@ -260,8 +260,8 @@ class Building:
                                 model_ele = SubElement(
                                     floor_ele,
                                     'model',
-                                    {'name':(f'ShaftDoor_{lift_name}_' + \
-                                        f'{level_name}_{door.name}')})
+                                    {'name': (f'ShaftDoor_{lift_name}_' +
+                                              f'{level_name}_{door.name}')})
 
         elif 'ignition' in options:
             plugin_ele = gui_ele.find('.//plugin[@filename="GzScene3D"]')

--- a/building_map_tools/building_map/building.py
+++ b/building_map_tools/building_map/building.py
@@ -247,6 +247,12 @@ class Building:
                             'model',
                             {'name': model.name})
 
+                for door in level.doors:
+                    model_ele = SubElement(
+                        floor_ele,
+                        'model',
+                        {'name': door.params['name'].value})
+
         elif 'ignition' in options:
             plugin_ele = gui_ele.find('.//plugin[@filename="GzScene3D"]')
             camera_pose_ele = plugin_ele.find('camera_pose')

--- a/building_map_tools/building_map/building.py
+++ b/building_map_tools/building_map/building.py
@@ -240,6 +240,13 @@ class Building:
                         'name': level_name,
                         'model_name': f'{self.name}_{level_name}'})
 
+                for model in level.models:
+                    if model.static:
+                        model_ele = SubElement(
+                            floor_ele,
+                            'model',
+                            {'name': model.name})
+
         elif 'ignition' in options:
             plugin_ele = gui_ele.find('.//plugin[@filename="GzScene3D"]')
             camera_pose_ele = plugin_ele.find('camera_pose')

--- a/building_map_tools/building_map/level.py
+++ b/building_map_tools/building_map/level.py
@@ -152,12 +152,9 @@ class Level:
                 self.transformed_vertices)
 
     def generate_sdf_models(self, world_ele):
-        model_cnt = 0
         for model in self.models:
-            model_cnt += 1
             model.generate(
                 world_ele,
-                model_cnt,
                 self.transform,
                 self.elevation)
 

--- a/building_map_tools/building_map/model.py
+++ b/building_map_tools/building_map/model.py
@@ -30,7 +30,7 @@ class Model:
 
         self.yaw = yaml_node['yaw']
 
-    def generate(self, world_ele, model_cnt, transform, elevation):
+    def generate(self, world_ele, transform, elevation):
         include_ele = SubElement(world_ele, 'include')
         name_ele = SubElement(include_ele, 'name')
         name_ele.text = self.name

--- a/building_sim_plugins/building_gazebo_plugins/CMakeLists.txt
+++ b/building_sim_plugins/building_gazebo_plugins/CMakeLists.txt
@@ -113,16 +113,18 @@ target_include_directories(lift
 
 add_library(toggle_floors SHARED src/toggle_floors.cpp)
 
+ament_target_dependencies(toggle_floors
+    Qt5
+    gazebo_ros
+    rmf_fleet_msgs
+    rclcpp
+)
+
 target_include_directories(toggle_floors
   PUBLIC
     ${GAZEBO_INCLUDE_DIRS}
     #${building_sim_common_INCLUDE_DIRS}
     ${Qt5Core_INCLUDE_DIRS}
-)
-
-target_link_libraries(toggle_floors
-  PUBLIC
-    Qt5::Widgets
 )
 
 ###############################

--- a/building_sim_plugins/building_gazebo_plugins/src/toggle_floors.cpp
+++ b/building_sim_plugins/building_gazebo_plugins/src/toggle_floors.cpp
@@ -47,13 +47,12 @@ public:
         floor_ele->GetAttribute("model_name")->GetAsString();
 
       std::vector<string> models;
-      for (sdf::ElementPtr model_ele = floor_ele->GetFirstElement();
-        model_ele;
-        model_ele = model_ele->GetNextElement("model"))
+      auto model_ele = floor_ele->GetElement("model");
+      while (model_ele)
       {
-        if (model_ele->GetName() != string("model"))
-          continue;
-        models.push_back(model_ele->GetAttribute("name")->GetAsString());
+        if (model_ele->HasAttribute("name"))
+          models.push_back(model_ele->GetAttribute("name")->GetAsString());
+        model_ele = model_ele->GetNextElement("model");
       }
 
       printf(

--- a/building_sim_plugins/building_gazebo_plugins/src/toggle_floors.cpp
+++ b/building_sim_plugins/building_gazebo_plugins/src/toggle_floors.cpp
@@ -45,6 +45,17 @@ public:
       string floor_name = floor_ele->GetAttribute("name")->GetAsString();
       string model_name =
         floor_ele->GetAttribute("model_name")->GetAsString();
+
+      std::vector<string> models;
+      for (sdf::ElementPtr model_ele = floor_ele->GetFirstElement();
+        model_ele;
+        model_ele = model_ele->GetNextElement("model"))
+      {
+        if (model_ele->GetName() != string("model"))
+          continue;
+        models.push_back(model_ele->GetAttribute("name")->GetAsString());
+      }
+
       printf(
         "ToggleFloors::Load found a floor element: [%s]->[%s]\n",
         floor_name.c_str(),
@@ -57,16 +68,17 @@ public:
       connect(
         button,
         &QAbstractButton::clicked,
-        [this, button, model_name]()
+        [this, button, model_name, models]()
         {
-          this->button_clicked(button, model_name);
+          this->button_clicked(button, model_name, models);
         });
       hbox->addWidget(button);
     }
     setLayout(hbox);
   }
 
-  void button_clicked(QPushButton* button, string model_name)
+  void button_clicked(
+    QPushButton* button, string model_name, std::vector<string> models)
   {
     bool visible = button->isChecked();
     printf(
@@ -78,6 +90,11 @@ public:
     visual_msg.set_name(model_name);
     visual_msg.set_visible(visible);
     visual_pub->Publish(visual_msg);
+    for (string model : models)
+    {
+      visual_msg.set_name(model);
+      visual_pub->Publish(visual_msg);
+    }
   }
 };
 

--- a/building_sim_plugins/building_gazebo_plugins/src/toggle_floors.cpp
+++ b/building_sim_plugins/building_gazebo_plugins/src/toggle_floors.cpp
@@ -13,18 +13,17 @@
 
 #include <string>
 #include <unordered_map>
+
 using std::string;
 using FleetState = rmf_fleet_msgs::msg::FleetState;
 using RobotState = rmf_fleet_msgs::msg::RobotState;
-
 
 class ToggleFloors : public gazebo::GUIPlugin
 {
   Q_OBJECT
   gazebo::transport::NodePtr node;
   gazebo::transport::PublisherPtr visual_pub;
-  std::unordered_map<string, bool> floor_states;
-  std::unordered_map<string, bool> robot_states;
+  std::unordered_map<string, std::atomic<bool>> floor_visibility;
   gazebo_ros::Node::SharedPtr ros_node;
   rclcpp::Subscription<FleetState>::SharedPtr fleet_state_sub;
 
@@ -46,6 +45,8 @@ public:
   {
     printf("ToggleFloors::Load()\n");
     ros_node = gazebo_ros::Node::Get(sdf);
+
+    // toggle non-static robots
     fleet_state_sub = ros_node->create_subscription<FleetState>(
       "/fleet_states", rclcpp::SystemDefaultsQoS(),
       [&](FleetState::UniquePtr msg)
@@ -55,15 +56,10 @@ public:
         visual_msg.set_parent_name("world");
         for (const RobotState& robot : msg->robots)
         {
-          visible = floor_states[robot.location.level_name];
-          if (robot_states.find(robot.name) == robot_states.end() ||
-            robot_states[robot.name] != visible)
-          {
-            robot_states[robot.name] = visible;
-            visual_msg.set_name(robot.name);
-            visual_msg.set_visible(visible);
-            visual_pub->Publish(visual_msg);
-          }
+          visible = floor_visibility[robot.location.level_name];
+          visual_msg.set_name(robot.name);
+          visual_msg.set_visible(visible);
+          visual_pub->Publish(visual_msg);
         }
       });
 
@@ -87,7 +83,7 @@ public:
           models.push_back(model_ele->GetAttribute("name")->GetAsString());
         model_ele = model_ele->GetNextElement("model");
       }
-      floor_states[floor_name] = true;
+      floor_visibility[floor_name] = true;
 
       printf(
         "ToggleFloors::Load found a floor element: [%s]->[%s]\n",
@@ -117,7 +113,7 @@ public:
     std::vector<string> models)
   {
     bool visible = button->isChecked();
-    floor_states[floor_name] = visible;
+    floor_visibility[floor_name] = visible;
     printf(
       "clicked: [%s] %s\n",
       model_name.c_str(),

--- a/building_sim_plugins/building_gazebo_plugins/src/toggle_floors.cpp
+++ b/building_sim_plugins/building_gazebo_plugins/src/toggle_floors.cpp
@@ -90,7 +90,7 @@ public:
     visual_msg.set_name(model_name);
     visual_msg.set_visible(visible);
     visual_pub->Publish(visual_msg);
-    for (string model : models)
+    for (const string& model : models)
     {
       visual_msg.set_name(model);
       visual_pub->Publish(visual_msg);


### PR DESCRIPTION
This PR adds the feature of hiding & showing the static models on each level in the toggle_floors plugin. Static model names are recorded in the plugin sdf specification and hide/show messages are published on click of the toggle floor button.
![Screenshot from 2020-08-31 17-56-53](https://user-images.githubusercontent.com/50894569/91708097-68e91300-ebb3-11ea-9197-7690270815f6.png)
![Screenshot from 2020-08-31 17-57-01](https://user-images.githubusercontent.com/50894569/91708101-6ab2d680-ebb3-11ea-810b-c5905f42310b.png)

