### PR TITLE
Create AxisAlignedBox component for slotcar

### DIFF
--- a/building_sim_plugins/building_ignition_plugins/src/slotcar.cpp
+++ b/building_sim_plugins/building_ignition_plugins/src/slotcar.cpp
@@ -8,6 +8,7 @@
 #include <ignition/gazebo/components/Name.hh>
 #include <ignition/gazebo/components/Pose.hh>
 #include <ignition/gazebo/components/Static.hh>
+#include <ignition/gazebo/components/AxisAlignedBox.hh>
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -122,6 +123,12 @@ void SlotcarPlugin::Configure(const Entity& entity,
   // Initialize Pose3d component
   if (!ecm.EntityHasComponentType(entity, components::Pose().TypeId()))
     ecm.CreateComponent(entity, components::Pose());
+  // Initialize Bounding Box component
+  if (!ecm.EntityHasComponentType(entity,
+    components::AxisAlignedBox().TypeId()))
+  {
+    ecm.CreateComponent(entity, components::AxisAlignedBox());
+  }
 }
 
 void SlotcarPlugin::init_infrastructure(EntityComponentManager& ecm)


### PR DESCRIPTION
Create component in plugin's `Configure` method, to be used later for other purposes including dispensing onto/ingesting from slotcar.