### PR TITLE
fix #232 ensuring that building filename is set

### DIFF
--- a/traffic_editor/gui/building.cpp
+++ b/traffic_editor/gui/building.cpp
@@ -388,8 +388,9 @@ void Building::set_model_yaw(
 
 void Building::clear()
 {
-  name = "";
-  reference_level_name = "";
+  name.clear();
+  filename.clear();
+  reference_level_name.clear();
   levels.clear();
   lifts.clear();
   clear_transform_cache();

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -699,7 +699,7 @@ void Editor::project_new()
   std::string fn = file_info.fileName().toStdString();
 
   project.clear();
-  project.filename = file_info.absoluteFilePath().toStdString();
+  project.set_filename(file_info.absoluteFilePath().toStdString());
   QString dir_path = file_info.dir().path();
   QDir::setCurrent(dir_path);
 
@@ -710,7 +710,7 @@ void Editor::project_new()
   QSettings settings;
   settings.setValue(
     preferences_keys::previous_project_path,
-    QString::fromStdString(project.filename));
+    QString::fromStdString(project.get_filename()));
 }
 
 void Editor::project_open()
@@ -808,7 +808,7 @@ void Editor::mouse_event(const MouseType t, QMouseEvent* e)
   {
     if (t == MOUSE_RELEASE)
     {
-      if (project.filename.empty())
+      if (project.get_filename().empty())
       {
         QMessageBox::critical(
           this,

--- a/traffic_editor/gui/project.cpp
+++ b/traffic_editor/gui/project.cpp
@@ -660,3 +660,57 @@ bool Project::has_sim_plugin()
   }
   return false;
 }
+
+bool Project::set_filename(const std::string& _fn)
+{
+  const string suffix(".project.yaml");
+
+  // ensure there is at least one character in addition to the suffix length
+  if (_fn.size() <= suffix.size())
+  {
+    printf("Project::set_filename() too short: [%s]\n", _fn.c_str());
+    return false;
+  }
+
+  // ensure the filename ends in .project.yaml
+  // it should, because the "save as" dialog appends it, but...
+  if (_fn.compare(_fn.size() - suffix.size(), suffix.size(), suffix))
+  {
+    printf(
+      "Project::set_filename() filename had unexpected suffix: [%s]\n",
+      _fn.c_str());
+    return false;
+  }
+
+  const string no_suffix(_fn.substr(0, _fn.size() - suffix.size()));
+
+  const size_t last_slash_pos = no_suffix.rfind('/', no_suffix.size());
+
+  const string stem(
+    (last_slash_pos == string::npos) ?
+    no_suffix :
+    string(no_suffix, last_slash_pos + 1));
+
+  filename = _fn;
+
+  if (name.empty())
+  {
+    name = stem;
+  }
+
+  if (building.name.empty())
+  {
+    building.name = stem;
+  }
+  if (building.filename.empty())
+  {
+    building.filename = stem + std::string(".building.yaml");
+  }
+
+  printf(
+    "set project filename to [%s] stem: [%s] building filename: [%s]\n",
+    filename.c_str(),
+    stem.c_str(),
+    building.filename.c_str());
+  return true;
+}

--- a/traffic_editor/gui/project.h
+++ b/traffic_editor/gui/project.h
@@ -39,7 +39,6 @@ class Project
 {
 public:
   std::string name;
-  std::string filename;
 
   Building building;
   std::vector<std::unique_ptr<Scenario>> scenarios;
@@ -130,6 +129,9 @@ public:
 
   bool has_sim_plugin();
 
+  bool set_filename(const std::string& _filename);
+  std::string get_filename() { return filename; }
+
 private:
   bool load_yaml_file(const std::string& _filename);
   bool save_yaml_file() const;
@@ -139,6 +141,7 @@ private:
     QGraphicsLineItem* line_item,
     const EditorModeId mode);
 
+  std::string filename;
 };
 
 #endif


### PR DESCRIPTION
fixes #232 by adding a getter/setter for the `Project` class `filename` member, ensuring that whenever it's set, it validates that the building has a sane filename, and if not, it creates a default filename for it.