### PR TITLE
Fix multiple wall textures

### DIFF
--- a/building_map_tools/building_map/wall.py
+++ b/building_map_tools/building_map/wall.py
@@ -217,7 +217,8 @@ class Wall:
 
         self.transformed_vertices = transformed_vertices
 
-        link_ele = SubElement(model_ele, 'link', {'name': 'walls'})
+        link_ele = SubElement(
+            model_ele, 'link', {'name': f'wall_{self.wall_cnt}'})
         self.generate_wall_visual_mesh(model_name, model_path)
 
         obj_path = f'model://{model_name}/meshes/wall_{self.wall_cnt}.obj'


### PR DESCRIPTION
The previous implementation for multiple wall textures will fail during launch with `gazebo11`. Simple fix