### PR TITLE
Add first pass of quality declarations for all packages

### DIFF
--- a/building_map_msgs/QUALITY_DECLARATION.md
+++ b/building_map_msgs/QUALITY_DECLARATION.md
@@ -1,0 +1,141 @@
+This document is a declaration of software quality for the `building_map_msgs` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `building_map_msgs` Quality Declaration
+
+The package `building_map_msgs` claims to be in the **Quality Level 3** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`building_map_msgs` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`building_map_msgs` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+All message definition files located the `msg` directory and service definition files located in the `srv` directory are considered part of the public API.
+
+### API Stability Within a Released ROS Distribution [1.iv]/[1.vi]
+
+`building_map_msgs` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+
+### ABI Stability Within a Released ROS Distribution [1.v]/[1.vi]
+
+`building_map_msgs` does not contain any C or C++ code and therefore will not affect ABI stability.
+
+## Change Control Process [2]
+
+`building_map_msgs` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`building_map_msgs` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`building_map_msgs` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+The CI checks only that the package builds.
+The most recent CI results can be seen on [the workflow page](https://github.com/osrf/traffic_editor/actions).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`building_map_msgs` has basic comments in the message and service definition files, but no list of messages, services, or usage guide is provided.
+New messages and services require their own documentation in order to be added.
+
+### Public API Documentation [3.ii]
+
+`building_map_msgs` has embedded API documentation, but it is not currently hosted.
+
+### License [3.iii]
+
+The license for `building_map_msgs` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+There are no source files that are currently copyrighted in this package so files are not checked for abbreviated license statements.
+
+### Copyright Statement [3.iv]
+
+There are no copyrighted source files in this package.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 3 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`building_map_msgs` is a package providing strictly message and service definitions and therefore does not require associated tests.
+
+### Public API Testing [4.ii]
+
+`building_map_msgs` is a package providing strictly message and service definitions and therefore does not require associated tests.
+
+### Coverage [4.iii]
+
+`building_map_msgs` is a package providing strictly message and service definitions and therefore has no coverage requirements.
+
+### Performance [4.iv]
+
+`building_map_msgs` is a package providing strictly message and service definitions and therefore has no performance requirements.
+
+### Linters and Static Analysis [4.v]
+
+`building_map_msgs` does not use the standard linters and static analysis tools for its generated C++ and Python code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`building_map_msgs` has the following runtime ROS dependencies.
+
+#### builtin\_interfaces
+
+`builtin_interfaces` is at [**Quality Level 3**](https://github.com/ros2/rcl_interfaces/tree/master/builtin_interfaces/QUALITY_DECLARATION.md)
+
+#### rosidl\_default_runtime
+
+`rosidl_default_runtime` is at [**Quality Level 3**](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
+
+#### geometry_msgs
+
+`geometry_msgs` is [**Quality Level 3**](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/QUALITY_DECLARATION.md).
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`building_map_msgs` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`building_map_msgs` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+As a pure message and service definitions package, `building_map_msgs` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/building_map_msgs/README.md
+++ b/building_map_msgs/README.md
@@ -1,0 +1,9 @@
+# building\_map\_msgs
+
+`building_map_msgs` provides message and service types for communicating about building infrastructure.
+
+For more information about ROS 2 interfaces, see [index.ros2.org](https://index.ros.org/doc/ros2/Concepts/About-ROS-Interfaces/)
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 3** category. See the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/building_map_tools/QUALITY_DECLARATION.md
+++ b/building_map_tools/QUALITY_DECLARATION.md
@@ -1,0 +1,154 @@
+This document is a declaration of software quality for the `building_map_tools` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `building_map_tools` Quality Declaration
+
+The package `building_map_tools` claims to be in the **Quality Level 4** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`building_map_tools` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`building_map_tools` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+All installed Python packages are part of the public API.
+
+### API Stability Policy [1.iv]
+
+`building_map_tools` will not break public API within a major version number.
+
+### ABI Stability Policy [1.v]
+
+`building_map_tools` will not break public ABI within a major version number.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`building_map_tools` will not break public API or ABI within a released ROS distribution, i.e. no major releases into the same ROS distribution once that ROS distribution is released.
+
+## Change Control Process [2]
+
+`building_map_tools` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`building_map_tools` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`building_map_tools` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+
+The most recent CI results can be seen on [the workflow page](https://github.com/osrf/rmf_core/actions?query=workflow%3Abuild+branch%3Amaster).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`building_map_tools` does not provide documentation.
+
+### Public API Documentation [3.ii]
+
+`building_map_tools` does not document its public API.
+
+### License [3.iii]
+
+The license for `building_map_tools` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+### Copyright Statement [3.iv]
+
+Copyright statements are not provided in the source files.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 4 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`building_map_tools` does not provide feature tests.
+
+### Public API Testing [4.ii]
+
+`building_map_tools` does not provide API tests.
+
+### Coverage [4.iii]
+
+`building_map_tools` does not track coverage statistics.
+
+### Performance [4.iv]
+
+`building_map_tools` does not test performance.
+
+### Linters and Static Analysis [4.v]
+
+`building_map_tools` does not use the standard linters and static analysis tools for its CMake code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+Below are the required direct runtime ROS dependencies of `building_map_tools` and their evaluations.
+
+#### rclpy
+
+`rclpy` does not declare a quality level.
+It is assumed to be **Quality Level 3** based on its wide-spread use, use of change control, use of CI, and use of testing.
+
+#### std_msgs
+
+`std_msgs` is [**Quality Level 3**](https://github.com/ros2/common_interfaces/blob/master/std_msgs/QUALITY_DECLARATION.md).
+
+#### building_map_msgs
+
+`building_map_msgs` is [**Quality Level 3**](https://github.com/osrf/traffic_editor/blob/master/building_map_msgs/QUALITY_DECLARATION.md).
+
+#### python3-requests
+
+`python3-requests` is assumed to be at **Quality Level 3** due to its wide-spread use, documentation, CI, and testing.
+
+#### python3-shapely
+
+`python3-shapely` is assumed to be at **Quality Level 3** due to its wide-spread use, documentation, CI, and testing.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`building_map_tools` has no optional runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`building_map_tools` has no runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+### Target platforms [6.i]
+
+`building_map_tools` does not support all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers).
+`building_map_tools` supports ROS Eloquent.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/building_map_tools/README.md
+++ b/building_map_tools/README.md
@@ -1,0 +1,7 @@
+# building\_map\_tools package
+
+This package provides tools for manipulating and format-converting building maps.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category. See the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/building_sim_plugins/building_gazebo_plugins/QUALITY_DECLARATION.md
+++ b/building_sim_plugins/building_gazebo_plugins/QUALITY_DECLARATION.md
@@ -1,0 +1,183 @@
+This document is a declaration of software quality for the `building_gazebo_plugins` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `building_gazebo_plugins` Quality Declaration
+
+The package `building_gazebo_plugins` claims to be in the **Quality Level 4** category.
+
+Below are the detailed rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`building_gazebo_plugins` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`building_gazebo_plugins` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+`building_gazebo_plugins` does not have a public API.
+
+### API Stability Policy [1.iv]
+
+`building_gazebo_plugins` does not have a public API.
+
+### ABI Stability Policy [1.v]
+
+`building_gazebo_plugins` does not have a public API.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`building_gazebo_plugins` does not have a public API.
+
+## Change Control Process [2]
+
+`building_gazebo_plugins` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`building_gazebo_plugins` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`building_gazebo_plugins` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+The CI checks only that the package builds.
+The most recent CI results can be seen on [the workflow page](https://github.com/osrf/traffic_editor/actions).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`building_gazebo_plugins` does not provide feature documentation.
+
+### Public API Documentation [3.ii]
+
+`building_gazebo_plugins` does not have a public API.
+
+### License [3.iii]
+
+The license for `building_gazebo_plugins` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+### Copyright Statement [3.iv]
+
+The copyright holders each provide a statement of copyright in each source code file in `rmf_demo_tasks`.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 4 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`building_gazebo_plugins` does not have any tests.
+
+### Public API Testing [4.ii]
+
+`building_gazebo_plugins` does not have a public API.
+
+### Coverage [4.iii]
+
+`building_gazebo_plugins` does not track coverage statistics.
+
+### Performance [4.iv]
+
+`building_gazebo_plugins` does not have performance tests.
+
+### Linters and Static Analysis [4.v]
+
+`building_gazebo_plugins` does not use the standard linters and static analysis tools for its CMake code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`building_gazebo_plugins` has the following direct runtime ROS dependencies.
+
+#### rclcpp
+
+`rclcpp` is [**Quality Level 3**](https://github.com/ros2/rclcpp/blob/master/rclcpp/QUALITY_DECLARATION.md).
+
+#### gazebo\_ros
+
+`gazebo_ros` does not declare a Quality Level.
+It is assumed tobe at **Quality Level 4** based on its widespread use.
+
+#### gazebo\_msgs
+
+`gazebo_ros_msgs` does not declare a Quality Level.
+It is assumed tobe at **Quality Level 4** based on its widespread use.
+
+#### gazebo\_dev
+
+`gazebo_dev` does not declare a Quality Level.
+It is assumed tobe at **Quality Level 4** based on its widespread use.
+
+#### rmf\_fleet\_msgs
+
+`rmf_fleet_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_fleet_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_door\_msgs
+
+`rmf_door_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_door_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_lift\_msgs
+
+`rmf_lift_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_lift_msgs/QUALITY_DECLARATION.md).
+
+#### tf2\_ros
+
+`gazebo_dev` does not declare a Quality Level.
+It is assumed tobe at **Quality Level 4** based on its widespread use and use of CI.
+
+#### geometry\_msgs
+
+`geometry_msgs` is [**Quality Level 3**](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/QUALITY_DECLARATION.md).
+
+#### std\_msgs
+
+`std_msgs` is [**Quality Level 3**](https://github.com/ros2/common_interfaces/blob/master/std_msgs/QUALITY_DECLARATION.md).
+
+#### std\_srvs
+
+`std_srvs` is [**Quality Level 3**](https://github.com/ros2/common_interfaces/blob/master/std_srvs/QUALITY_DECLARATION.md).
+
+#### building\_sim\_common
+
+`building_sim_common` is [**Quality Level 4**](https://github.com/osrf/traffic_editor/blob/master/building_sim_plugins/building_sim_common/QUALITY_DECLARATION.md).
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`building_gazebo_plugins` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`building_gazebo_plugins` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+`building_gazebo_plugins` does not support all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers).
+`building_gazebo_plugins` supports ROS Eloquent and ROS Foxy.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/building_sim_plugins/building_gazebo_plugins/README.md
+++ b/building_sim_plugins/building_gazebo_plugins/README.md
@@ -1,0 +1,7 @@
+# building\_gazebo\_plugins
+
+This package provides Gazebo simulator plugins for allowing simulated building infrastructure to communicate with a ROS system.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.

--- a/building_sim_plugins/building_ignition_plugins/QUALITY_DECLARATION.md
+++ b/building_sim_plugins/building_ignition_plugins/QUALITY_DECLARATION.md
@@ -1,0 +1,168 @@
+This document is a declaration of software quality for the `building_ignition_plugins` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `building_ignition_plugins` Quality Declaration
+
+The package `building_ignition_plugins` claims to be in the **Quality Level 4** category.
+
+Below are the detailed rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`building_ignition_plugins` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`building_ignition_plugins` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+`building_ignition_plugins` does not have a public API.
+
+### API Stability Policy [1.iv]
+
+`building_ignition_plugins` does not have a public API.
+
+### ABI Stability Policy [1.v]
+
+`building_ignition_plugins` does not have a public API.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`building_ignition_plugins` does not have a public API.
+
+## Change Control Process [2]
+
+`building_ignition_plugins` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`building_ignition_plugins` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`building_ignition_plugins` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+The CI checks only that the package builds.
+The most recent CI results can be seen on [the workflow page](https://github.com/osrf/traffic_editor/actions).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`building_ignition_plugins` does not provide feature documentation.
+
+### Public API Documentation [3.ii]
+
+`building_ignition_plugins` does not have a public API.
+
+### License [3.iii]
+
+The license for `building_ignition_plugins` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+### Copyright Statement [3.iv]
+
+The copyright holders each provide a statement of copyright in each source code file in `rmf_demo_tasks`.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 4 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`building_ignition_plugins` does not have any tests.
+
+### Public API Testing [4.ii]
+
+`building_ignition_plugins` does not have a public API.
+
+### Coverage [4.iii]
+
+`building_ignition_plugins` does not track coverage statistics.
+
+### Performance [4.iv]
+
+`building_ignition_plugins` does not have performance tests.
+
+### Linters and Static Analysis [4.v]
+
+`building_ignition_plugins` does not use the standard linters and static analysis tools for its CMake code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`building_ignition_plugins` has the following direct runtime ROS dependencies.
+
+#### rclcpp
+
+`rclcpp` is [**Quality Level 3**](https://github.com/ros2/rclcpp/blob/master/rclcpp/QUALITY_DECLARATION.md).
+
+#### rmf\_fleet\_msgs
+
+`rmf_fleet_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_fleet_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_door\_msgs
+
+`rmf_door_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_door_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_lift\_msgs
+
+`rmf_lift_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_lift_msgs/QUALITY_DECLARATION.md).
+
+#### tf2\_ros
+
+`ignition_dev` does not declare a Quality Level.
+It is assumed tobe at **Quality Level 4** based on its widespread use and use of CI.
+
+#### geometry\_msgs
+
+`geometry_msgs` is [**Quality Level 3**](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/QUALITY_DECLARATION.md).
+
+#### std\_msgs
+
+`std_msgs` is [**Quality Level 3**](https://github.com/ros2/common_interfaces/blob/master/std_msgs/QUALITY_DECLARATION.md).
+
+#### std\_srvs
+
+`std_srvs` is [**Quality Level 3**](https://github.com/ros2/common_interfaces/blob/master/std_srvs/QUALITY_DECLARATION.md).
+
+#### building\_sim\_common
+
+`building_sim_common` is [**Quality Level 4**](https://github.com/osrf/traffic_editor/blob/master/building_sim_plugins/building_sim_common/QUALITY_DECLARATION.md).
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`building_ignition_plugins` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`building_ignition_plugins` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+`building_ignition_plugins` does not support all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers).
+`building_ignition_plugins` supports ROS Eloquent and ROS Foxy.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/building_sim_plugins/building_ignition_plugins/README.md
+++ b/building_sim_plugins/building_ignition_plugins/README.md
@@ -1,0 +1,7 @@
+# building\_gazebo\_plugins
+
+This package provides Ignition plugins for allowing simulated building infrastructure to communicate with a ROS system.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.

--- a/building_sim_plugins/building_plugins_common/QUALITY_DECLARATION.md
+++ b/building_sim_plugins/building_plugins_common/QUALITY_DECLARATION.md
@@ -1,0 +1,172 @@
+This document is a declaration of software quality for the `building_plugins_common` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `building_plugins_common` Quality Declaration
+
+The package `building_plugins_common` claims to be in the **Quality Level 4** category.
+
+Below are the detailed rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`building_plugins_common` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`building_plugins_common` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+All symbols in the installed headers are considered part of the public API.
+
+All installed headers are in the `include` directory of the package.
+Headers in any other folders are not installed and are considered private.
+
+### API Stability Policy [1.iv]
+
+`building_plugins_common` will not break public API within a major version number.
+
+### ABI Stability Policy [1.v]
+
+`building_plugins_common` will not break public ABI within a major version number.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`building_plugins_common` will not break public API or ABI within a released ROS distribution, i.e. no major releases into the same ROS distribution once that ROS distribution is released.
+
+## Change Control Process [2]
+
+`building_plugins_common` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`building_plugins_common` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`building_plugins_common` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+The CI checks only that the package builds.
+The most recent CI results can be seen on [the workflow page](https://github.com/osrf/traffic_editor/actions).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`building_plugins_common` does not provide feature documentation.
+
+### Public API Documentation [3.ii]
+
+`building_plugins_common` does not provide API documentation.
+
+### License [3.iii]
+
+The license for `building_plugins_common` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+### Copyright Statement [3.iv]
+
+The copyright holders each provide a statement of copyright in each source code file in `rmf_demo_tasks`.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 4 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`building_plugins_common` does not have any feature tests.
+
+### Public API Testing [4.ii]
+
+`building_plugins_common` does not have any API tests.
+
+### Coverage [4.iii]
+
+`building_plugins_common` does not track coverage statistics.
+
+### Performance [4.iv]
+
+`building_plugins_common` does not have performance tests.
+
+### Linters and Static Analysis [4.v]
+
+`building_plugins_common` does not use the standard linters and static analysis tools for its CMake code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`building_plugins_common` has the following direct runtime ROS dependencies.
+
+#### rclcpp
+
+`rclcpp` is [**Quality Level 3**](https://github.com/ros2/rclcpp/blob/master/rclcpp/QUALITY_DECLARATION.md).
+
+#### rmf\_fleet\_msgs
+
+`rmf_fleet_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_fleet_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_door\_msgs
+
+`rmf_door_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_door_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_lift\_msgs
+
+`rmf_lift_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_lift_msgs/QUALITY_DECLARATION.md).
+
+#### tf2\_ros
+
+`gazebo_dev` does not declare a Quality Level.
+It is assumed tobe at **Quality Level 4** based on its widespread use and use of CI.
+
+#### geometry\_msgs
+
+`geometry_msgs` is [**Quality Level 3**](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/QUALITY_DECLARATION.md).
+
+#### std\_msgs
+
+`std_msgs` is [**Quality Level 3**](https://github.com/ros2/common_interfaces/blob/master/std_msgs/QUALITY_DECLARATION.md).
+
+#### std\_srvs
+
+`std_srvs` is [**Quality Level 3**](https://github.com/ros2/common_interfaces/blob/master/std_srvs/QUALITY_DECLARATION.md).
+
+#### building_map_msgs
+
+`building_map_msgs` is [**Quality Level 3**](https://github.com/osrf/traffic_editor/blob/master/building_map_msgs/QUALITY_DECLARATION.md).
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`building_plugins_common` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`building_plugins_common` depends on `menge`.
+`menge` is assumed to be **Quality Level 4**.
+
+## Platform Support [6]
+
+`building_plugins_common` does not support all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers).
+`building_plugins_common` supports ROS Eloquent and ROS Foxy.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/building_sim_plugins/building_plugins_common/README.md
+++ b/building_sim_plugins/building_plugins_common/README.md
@@ -1,0 +1,7 @@
+# building\_plugins\_common
+
+This package provides a common library for the Ignition and Gazebo simulator plugins for simulated building infrastructure.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.

--- a/test_maps/QUALITY_DECLARATION.md
+++ b/test_maps/QUALITY_DECLARATION.md
@@ -1,0 +1,133 @@
+This document is a declaration of software quality for the `test_maps` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `test_maps` Quality Declaration
+
+The package `test_maps` claims to be in the **Quality Level 3** category.
+The main rationale for this claim its its status as a collection of demonstration map files.
+
+Below are the detailed rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`test_maps` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`test_maps` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+`test_maps` does not have a public API.
+
+### API Stability Policy [1.iv]
+
+`test_maps` does not have a public API.
+
+### ABI Stability Policy [1.v]
+
+`test_maps` does not have a public API.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`test_maps` does not have a public API.
+
+## Change Control Process [2]
+
+`test_maps` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`test_maps` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`test_maps` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+The CI checks only that the package builds.
+The most recent CI results can be seen on [the workflow page](https://github.com/osrf/traffic_editor/actions).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`test_maps` is documented in the [parent repository's README.md file](https://github.com/osrf/traffic_editor/blob/master/README.md).
+
+### Public API Documentation [3.ii]
+
+`test_maps` does not have a public API.
+
+### License [3.iii]
+
+The license for `test_maps` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+There are no source files that are currently copyrighted in this package so files are not checked for abbreviated license statements.
+
+### Copyright Statement [3.iv]
+
+There are no copyrighted source files in this package.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 3 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`test_maps` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Public API Testing [4.ii]
+
+`test_maps` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Coverage [4.iii]
+
+`test_maps` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Performance [4.iv]
+
+`test_maps` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Linters and Static Analysis [4.v]
+
+`test_maps` has no files that require linting or static analysis.
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`test_maps` does not have any required direct runtime ROS dependencies.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`test_maps` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`test_maps` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+As a pure resource package, `test_maps` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/test_maps/README.md
+++ b/test_maps/README.md
@@ -1,0 +1,7 @@
+# test\_maps
+
+This package provides maps for testing the traffic editor.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 3** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.

--- a/traffic_editor/QUALITY_DECLARATION.md
+++ b/traffic_editor/QUALITY_DECLARATION.md
@@ -1,0 +1,158 @@
+This document is a declaration of software quality for the `traffic_editor` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `traffic_editor` Quality Declaration
+
+The package `traffic_editor` claims to be in the **Quality Level 4** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`traffic_editor` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`traffic_editor` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+All symbols in the installed headers are considered part of the public API.
+
+All installed headers are in the `include` directory of the package.
+Headers in any other folders are not installed and are considered private.
+
+### API Stability Policy [1.iv]
+
+`traffic_editor` will not break public API within a major version number.
+
+### ABI Stability Policy [1.v]
+
+`traffic_editor` will not break public ABI within a major version number.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`traffic_editor` will not break public API or ABI within a released ROS distribution, i.e. no major releases into the same ROS distribution once that ROS distribution is released.
+
+## Change Control Process [2]
+
+`traffic_editor` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`traffic_editor` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`traffic_editor` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+The CI checks only that the package builds.
+The most recent CI results can be seen on [the workflow page](https://github.com/osrf/traffic_editor/actions).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`traffic_editor` provides usage documentation in its [README file](README.md).
+
+### Public API Documentation [3.ii]
+
+`traffic_editor` does not document its public API.
+
+### License [3.iii]
+
+The license for `traffic_editor` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+### Copyright Statement [3.iv]
+
+The copyright holders each provide a statement of copyright in each source code file in `traffic_editor`.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 4 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`traffic_editor` does not have feature tests.
+
+### Public API Testing [4.ii]
+
+`traffic_editor` does not have API tests.
+
+### Coverage [4.iii]
+
+`traffic_editor` does not track coverage statistics.
+
+### Performance [4.iv]
+
+`traffic_editor` does not test performance.
+
+### Linters and Static Analysis [4.v]
+
+`traffic_editor` does not use the standard linters and static analysis tools for its CMake code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`traffic_editor` has no direct runtime ROS dependencies.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`traffic_editor` has no optional runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+Below are the required direct runtime non-ROS dependencies of `traffic_editor` and their evaluations.
+
+#### ignition-plugin
+
+`ignition-plugin` is assumed to be **Quality Level 3** based on its change control process, CI, tests, and documentation.
+
+#### ignition-common3
+
+`ignition-common3` is assumed to be **Quality Level 3** based on its change control process, CI, tests, and documentation.
+
+#### yaml-cpp
+
+The [`yaml-cpp` library](https://github.com/jbeder/yaml-cpp) is assumed to be **Quality Level 3** due to its wide use, provided documentation, use of testing, and version number above 1.0.0.
+
+#### libqt5-concurrent
+
+`libqt5-concurrent` is widely-used third-party software for building graphical applications.
+Due to its wide use, documentation, and testing, it is assumed to be **Quality Level 3**.
+
+#### libqt5-widgets
+
+`libqt5-widgets` is widely-used third-party software for building graphical applications.
+Due to its wide use, documentation, and testing, it is assumed to be **Quality Level 3**.
+
+## Platform Support [6]
+
+### Target platforms [6.i]
+
+`traffic_editor` does not support all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers).
+`traffic_editor` supports ROS Eloquent.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/traffic_editor/README.md
+++ b/traffic_editor/README.md
@@ -5,6 +5,11 @@ A graphical editor for robot traffic flows. The intent is to make it easy
 to annotate building floorplans with the desired robot traffic lanes and
 generate simulation models to test and evaluate different traffic schemes.
 
+## Quality Declaration
+
+This package claims to be in the **Quality Level 3** category.
+See the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.
+
 ## System Requirements
 
 This program is developed and tested on


### PR DESCRIPTION
This PR adds [quality declaration documents](https://www.ros.org/reps/rep-2004.html) and (where necessary) basic README files too all packages in `traffic_editor`.

The message packages meet the requirements to be Quality Level 3. All source-code-containing packages are currently QL4.

We need to go over each declaration and discuss it, making sure we all agree on the arguments being made.

Once this PR goes in, we can make a list of tasks that need to be done to move the packages up to higher quality levels.