### PR TITLE
Fixing vertices incorrectly generated after quitting previous edge drawing

### DIFF
--- a/traffic_editor/gui/building.cpp
+++ b/traffic_editor/gui/building.cpp
@@ -149,6 +149,19 @@ bool Building::save_yaml_file()
   return true;
 }
 
+void Building::remove_vertex(int level_index, int vertex_index) {
+  if (level_index >= static_cast<int>(levels.size())
+    || vertex_index >= static_cast<int>(levels[level_index].vertices.size()))
+    return;
+  for (auto edge : levels[level_index].edges) {
+    // cannot remove a vertex on an edge
+    if (edge.start_idx == vertex_index || edge.end_idx == vertex_index)
+      return;
+  }
+  levels[level_index].vertices
+    .erase(levels[level_index].vertices.begin() + vertex_index);
+}
+
 void Building::add_vertex(int level_index, double x, double y)
 {
   if (level_index >= static_cast<int>(levels.size()))

--- a/traffic_editor/gui/building.cpp
+++ b/traffic_editor/gui/building.cpp
@@ -154,7 +154,8 @@ void Building::remove_vertex(int level_index, int vertex_index)
   if (level_index >= static_cast<int>(levels.size())
     || vertex_index >= static_cast<int>(levels[level_index].vertices.size()))
     return;
-  for (auto edge : levels[level_index].edges) {
+  for (auto edge : levels[level_index].edges)
+  {
     // cannot remove a vertex on an edge
     if (edge.start_idx == vertex_index || edge.end_idx == vertex_index)
       return;

--- a/traffic_editor/gui/building.cpp
+++ b/traffic_editor/gui/building.cpp
@@ -149,10 +149,10 @@ bool Building::save_yaml_file()
   return true;
 }
 
-void Building::remove_vertex(int level_index, int vertex_index)
+void Building::remove_last_vertex(int level_index)
 {
-  if (level_index >= static_cast<int>(levels.size())
-    || vertex_index >= static_cast<int>(levels[level_index].vertices.size()))
+  int vertex_index = levels[level_index].vertices.size() - 1;
+  if (level_index >= static_cast<int>(levels.size()))
     return;
   for (auto edge : levels[level_index].edges)
   {
@@ -160,8 +160,14 @@ void Building::remove_vertex(int level_index, int vertex_index)
     if (edge.start_idx == vertex_index || edge.end_idx == vertex_index)
       return;
   }
-  levels[level_index].vertices
-  .erase(levels[level_index].vertices.begin() + vertex_index);
+  for (auto polygon : levels[level_index].polygons)
+  {
+    // cannot remove a vertex on a polygon
+    if (find(polygon.vertices.begin(), polygon.vertices.end(), vertex_index)
+      != polygon.vertices.end())
+      return;
+  }
+  levels[level_index].vertices.pop_back();
 }
 
 void Building::add_vertex(int level_index, double x, double y)

--- a/traffic_editor/gui/building.cpp
+++ b/traffic_editor/gui/building.cpp
@@ -149,7 +149,8 @@ bool Building::save_yaml_file()
   return true;
 }
 
-void Building::remove_vertex(int level_index, int vertex_index) {
+void Building::remove_vertex(int level_index, int vertex_index)
+{
   if (level_index >= static_cast<int>(levels.size())
     || vertex_index >= static_cast<int>(levels[level_index].vertices.size()))
     return;
@@ -159,7 +160,7 @@ void Building::remove_vertex(int level_index, int vertex_index) {
       return;
   }
   levels[level_index].vertices
-    .erase(levels[level_index].vertices.begin() + vertex_index);
+  .erase(levels[level_index].vertices.begin() + vertex_index);
 }
 
 void Building::add_vertex(int level_index, double x, double y)

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -898,7 +898,7 @@ void Editor::keyPressEvent(QKeyEvent* e)
     case Qt::Key_S:
     case Qt::Key_Escape:
       if (clicked_idx > -1 && added_vertex)
-        project.building.remove_vertex(level_idx, clicked_idx);
+        project.building.remove_last_vertex(level_idx);
       clicked_idx = -1;
       added_vertex = false;
       tool_button_group->button(TOOL_SELECT)->click();
@@ -1755,7 +1755,7 @@ void Editor::mouse_add_edge(
     {
       // right button means "exit edge drawing mode please"
       if (clicked_idx > -1 && added_vertex)
-        project.building.remove_vertex(level_idx, clicked_idx);
+        project.building.remove_last_vertex(level_idx);
       clicked_idx = -1;
       added_vertex = false;
       remove_mouse_motion_item();

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -897,9 +897,10 @@ void Editor::keyPressEvent(QKeyEvent* e)
       break;
     case Qt::Key_S:
     case Qt::Key_Escape:
-      if (clicked_idx > -1)
+      if (clicked_idx > -1 && added_vertex)
         project.building.remove_vertex(level_idx, clicked_idx);
       clicked_idx = -1;
+      added_vertex = false;
       tool_button_group->button(TOOL_SELECT)->click();
       project.clear_selection(level_idx);
       update_property_editor();
@@ -985,6 +986,7 @@ void Editor::tool_toggled(int id, bool checked)
     return;
 
   clicked_idx = -1;
+  added_vertex = false;
   remove_mouse_motion_item();
 
   tool_id = static_cast<ToolId>(id);
@@ -1752,9 +1754,10 @@ void Editor::mouse_add_edge(
     if (e->buttons() & Qt::RightButton)
     {
       // right button means "exit edge drawing mode please"
-      if (clicked_idx > -1)
+      if (clicked_idx > -1 && added_vertex)
         project.building.remove_vertex(level_idx, clicked_idx);
       clicked_idx = -1;
+      added_vertex = false;
       remove_mouse_motion_item();
       return;
     }
@@ -1767,6 +1770,7 @@ void Editor::mouse_add_edge(
     {
       // current click is not on an existing vertex. Add one.
       project.building.add_vertex(level_idx, p_aligned.x(), p_aligned.y());
+      added_vertex = true;
 
       // set the new vertex as "clicked_idx"  todo: encapsulate better
       clicked_idx =
@@ -1800,6 +1804,7 @@ void Editor::mouse_add_edge(
     if (edge_type == Edge::DOOR || edge_type == Edge::MEAS)
     {
       clicked_idx = -1;  // doors and measurements don't usually chain
+      added_vertex = false;
       remove_mouse_motion_item();
     }
 

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -897,6 +897,9 @@ void Editor::keyPressEvent(QKeyEvent* e)
       break;
     case Qt::Key_S:
     case Qt::Key_Escape:
+      if (clicked_idx > -1)
+        project.building.remove_vertex(level_idx, clicked_idx);
+      clicked_idx = -1;
       tool_button_group->button(TOOL_SELECT)->click();
       project.clear_selection(level_idx);
       update_property_editor();
@@ -1749,6 +1752,8 @@ void Editor::mouse_add_edge(
     if (e->buttons() & Qt::RightButton)
     {
       // right button means "exit edge drawing mode please"
+      if (clicked_idx > -1)
+        project.building.remove_vertex(level_idx, clicked_idx);
       clicked_idx = -1;
       remove_mouse_motion_item();
       return;

--- a/traffic_editor/gui/editor.h
+++ b/traffic_editor/gui/editor.h
@@ -161,6 +161,7 @@ private:
   Project project;
   int level_idx = 0;  // level that we are currently editing
   int clicked_idx = -1;  // point most recently clicked
+  bool added_vertex = false;  // we added a new vertex when drawing the edge
   //int polygon_idx = -1;  // currently selected polygon
   Polygon* selected_polygon = nullptr;
 

--- a/traffic_editor/include/traffic_editor/building.h
+++ b/traffic_editor/include/traffic_editor/building.h
@@ -53,7 +53,7 @@ public:
   void clear();  // clear all internal data structures
 
   void add_level(const BuildingLevel& level);
-  void remove_vertex(int level_idx, int vertex_idx);
+  void remove_last_vertex(int level_idx);
   void add_vertex(int level_index, double x, double y);
   void add_fiducial(int level_index, double x, double y);
 

--- a/traffic_editor/include/traffic_editor/building.h
+++ b/traffic_editor/include/traffic_editor/building.h
@@ -53,7 +53,7 @@ public:
   void clear();  // clear all internal data structures
 
   void add_level(const BuildingLevel& level);
-
+  void remove_vertex(int level_idx, int vertex_idx);
   void add_vertex(int level_index, double x, double y);
   void add_fiducial(int level_index, double x, double y);
 


### PR DESCRIPTION
There is a bug mentioned in [this issue](https://github.com/osrf/traffic_editor/issues/78) that adding edges after cancelling the previous drawing with right click would create an extra vertex. I also found that pressing esc key would have the same effect. This PR has a fix to that issue. So far it is working well when I test it at my end.