### PR TITLE
only build plugin support if ignition-plugin is present

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,3 +38,39 @@ jobs:
         cd ws
         source /opt/ros/eloquent/setup.bash
         colcon build --packages-select traffic_editor --cmake-args -DNO_DOWNLOAD_MODELS=True
+
+  build_without_plugin_support:
+    runs-on: ubuntu-18.04
+    container:
+      image: docker://ros:eloquent-ros-base-bionic
+
+    steps:
+    - name: osrf-repo
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y wget
+        echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable bionic main" > /etc/apt/sources.list.d/gazebo-stable.list
+        wget https://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
+        sudo apt-get update
+
+    - name: ros-workspace
+      run: |
+        mkdir -p ws/src
+
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        path: ws/src/traffic_editor
+
+    - name: non-ros-deps
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y git cmake wget libyaml-cpp-dev qt5-default
+
+    - name: build
+      shell: bash
+      run: |
+        cd ws
+        source /opt/ros/eloquent/setup.bash
+        colcon build --packages-select traffic_editor --cmake-args -DNO_DOWNLOAD_MODELS=True

--- a/traffic_editor/CMakeLists.txt
+++ b/traffic_editor/CMakeLists.txt
@@ -23,8 +23,8 @@ if(CMAKE_VERSION VERSION_LESS "3.7.0")
 endif()
 
 find_package(Qt5 COMPONENTS Widgets Concurrent REQUIRED)
-find_package(ignition-plugin1 REQUIRED COMPONENTS all)
-find_package(ignition-common3 REQUIRED)
+find_package(ignition-plugin1 QUIET COMPONENTS all)
+find_package(ignition-common3 QUIET)
 find_package(ament_index_cpp REQUIRED)
 
 # OpenCV is an optional dependency, only needed if you want to make videos
@@ -36,7 +36,7 @@ include_directories(gui)
 include_directories(include)
 include_directories(${ament_index_cpp_INCLUDE_DIRS})
 
-add_executable(traffic-editor
+set(traffic_editor_sources
   gui/add_param_dialog.cpp
   gui/building.cpp
   gui/building_dialog.cpp
@@ -68,7 +68,6 @@ add_executable(traffic-editor
   gui/scenario_dialog.cpp
   gui/scenario_level.cpp
   gui/scenario_table.cpp
-  gui/sim_thread.cpp
   gui/table_list.cpp
   gui/traffic_table.cpp
   gui/traffic_map.cpp
@@ -78,16 +77,35 @@ add_executable(traffic-editor
   resources/resource.qrc
 )
 
-target_link_libraries(traffic-editor
+set(traffic_editor_libs
   Qt5::Widgets
   Qt5::Concurrent
-  ignition-plugin1::core
-  ignition-plugin1::loader
-  ignition-common3::core
   yaml-cpp
   ${ament_index_cpp_LIBRARIES}
   ${OpenCV_LIBS}
 )
+
+if (ignition-plugin1_VERSION)
+  set(traffic_editor_sources
+    ${traffic_editor_sources}
+    gui/sim_thread.cpp
+  )
+  set(traffic_editor_libs
+    ${traffic_editor_libs}
+    ignition-plugin1::core
+    ignition-plugin1::loader
+    ignition-common3::core
+  )
+endif()
+
+add_executable(traffic-editor ${traffic_editor_sources})
+target_link_libraries(traffic-editor ${traffic_editor_libs})
+
+if (ignition-plugin1_VERSION)
+  # sadly this if() block has to come after add_executable(), but
+  # the if() block determining the sources has to go before add_executable()
+  target_compile_definitions(traffic-editor PUBLIC "HAS_IGNITION_PLUGIN")
+endif()
 
 if (OpenCV_VERSION)
   target_compile_definitions(traffic-editor PUBLIC "HAS_OPENCV")

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -370,6 +370,7 @@ Editor::Editor()
 
   toolbar->addSeparator();
 
+#ifdef HAS_IGNITION_PLUGIN
   sim_reset_action = toolbar->addAction(
     "Reset",
     this,
@@ -388,7 +389,9 @@ Editor::Editor()
     this,
     &Editor::record_start_stop);
   record_start_stop_action->setVisible(false);
-#endif
+#endif  // HAS_OPENCV
+
+#endif  // HAS_IGNITION_PLUGIN
 
   toolbar->setStyleSheet(
     "QToolBar {background-color: #404040; border: none; spacing: 5px} QToolButton {background-color: #c0c0c0; color: blue; border: 1px solid black;} QToolButton:checked {background-color: #808080; color: red; border: 1px solid black;}");
@@ -426,6 +429,7 @@ Editor::Editor()
   load_model_names();
   level_table->setCurrentCell(level_idx, 0);
 
+#ifdef HAS_IGNITION_PLUGIN
   scene_update_timer = new QTimer;
   connect(
     scene_update_timer,
@@ -433,11 +437,12 @@ Editor::Editor()
     this,
     &Editor::scene_update_timer_timeout);
   scene_update_timer->start(1000 / 30);
+#endif
 }
 
 Editor::~Editor()
 {
-#ifdef HAS_OPENCV
+#if defined(HAS_OPENCV) && defined(HAS_IGNITION_PLUGIN)
   if (video_writer)
   {
     delete video_writer;
@@ -446,6 +451,7 @@ Editor::~Editor()
 #endif
 }
 
+#ifdef HAS_IGNITION_PLUGIN
 void Editor::scene_update_timer_timeout()
 {
   if (project.building.levels.empty())
@@ -484,8 +490,9 @@ void Editor::scene_update_timer_timeout()
 
 #ifdef HAS_OPENCV
   record_frame_to_video();
-#endif
+#endif  // HAS_OPENCV
 }
+#endif  // HAS_IGNITION_PLUGIN
 
 void Editor::load_model_names()
 {
@@ -599,6 +606,7 @@ bool Editor::load_project(const QString& filename)
 
   update_tables();
 
+#ifdef HAS_IGNITION_PLUGIN
   if (project.has_sim_plugin())
   {
     printf("project has a sim plugin\n");
@@ -610,6 +618,7 @@ bool Editor::load_project(const QString& filename)
   }
   else
     printf("project does not have a sim plugin\n");
+#endif
 
   QSettings settings;
   settings.setValue(preferences_keys::previous_project_path, filename);
@@ -1515,7 +1524,9 @@ void Editor::property_editor_cell_changed(int row, int column)
 bool Editor::create_scene()
 {
   scene->clear();  // destroys the mouse_motion_* items if they are there
+#ifdef HAS_IGNITION_PLUGIN
   project.clear_scene();  // forget all pointers to the graphics items
+#endif
   mouse_motion_line = nullptr;
   mouse_motion_model = nullptr;
   mouse_motion_ellipse = nullptr;
@@ -2257,15 +2268,19 @@ bool Editor::maybe_save()
 void Editor::showEvent(QShowEvent* event)
 {
   QMainWindow::showEvent(event);
+#ifdef HAS_IGNITION_PLUGIN
   sim_thread.start();
+#endif
 }
 
 void Editor::closeEvent(QCloseEvent* event)
 {
+#ifdef HAS_IGNITION_PLUGIN
   printf("waiting on sim_thread...\n");
   sim_thread.requestInterruption();
   sim_thread.quit();
   sim_thread.wait();
+#endif
 
   // save window geometry
   QSettings settings;
@@ -2350,6 +2365,7 @@ void Editor::update_tables()
   traffic_table->update(project);
 }
 
+#ifdef HAS_IGNITION_PLUGIN
 void Editor::sim_reset()
 {
   printf("TODO: sim_reset()\n");
@@ -2360,6 +2376,14 @@ void Editor::sim_play_pause()
 {
   printf("sim_play_pause()\n");
   project.sim_is_paused = !project.sim_is_paused;
+}
+
+void Editor::sim_tick()
+{
+  // called from sim thread
+
+  if (!project.sim_is_paused)
+    project.sim_tick();
 }
 
 #ifdef HAS_OPENCV
@@ -2400,12 +2424,6 @@ void Editor::record_frame_to_video()
 
   video_writer->write(mat_rgb_swap);
 }
-#endif
+#endif  // HAS_OPENCV
 
-void Editor::sim_tick()
-{
-  // called from sim thread
-
-  if (!project.sim_is_paused)
-    project.sim_tick();
-}
+#endif  // HAS_IGNITION_PLUGIN

--- a/traffic_editor/gui/editor.h
+++ b/traffic_editor/gui/editor.h
@@ -33,7 +33,10 @@
 #include "project.h"
 #include "traffic_editor/editor_model.h"
 #include "editor_mode_id.h"
+
+#ifdef HAS_IGNITION_PLUGIN
 #include "sim_thread.h"
+#endif
 
 class BuildingLevelTable;
 class MapView;
@@ -228,23 +231,27 @@ private:
   void add_param_button_clicked();
   void delete_param_button_clicked();
 
+#ifdef HAS_IGNITION_PLUGIN
   QAction* sim_reset_action;
   QAction* sim_play_pause_action;
   void sim_reset();
   void sim_play_pause();
   SimThread sim_thread;
+#endif
 
 public:
   void sim_tick();  // called by SimThread
 
 private:
 
-#ifdef HAS_OPENCV
+#if defined(HAS_IGNITION_PLUGIN) && defined(HAS_OPENCV)
   QAction* record_start_stop_action;
   bool is_recording = false;
   void record_start_stop();
   void record_frame_to_video();
   cv::VideoWriter* video_writer = nullptr;
+  QTimer* scene_update_timer;
+  void scene_update_timer_timeout();
 #endif
 
   std::vector<EditorModel> editor_models;
@@ -317,9 +324,6 @@ private:
   void mouse_edit_polygon(const MouseType t, QMouseEvent* e, const QPointF& p);
 
   QPointF previous_mouse_point;
-
-  QTimer* scene_update_timer;
-  void scene_update_timer_timeout();
 };
 
 #endif

--- a/traffic_editor/gui/project.cpp
+++ b/traffic_editor/gui/project.cpp
@@ -612,6 +612,7 @@ void Project::clear()
   scenario_idx = -1;
 }
 
+#ifdef HAS_IGNITION_PLUGIN
 void Project::sim_tick()
 {
   if (scenario_idx < 0 || scenario_idx >= static_cast<int>(scenarios.size()))
@@ -625,13 +626,16 @@ void Project::sim_reset()
     return;
   scenarios[scenario_idx]->sim_reset(building);
 }
+#endif
 
 void Project::clear_scene()
 {
   building.clear_scene();
 
+#ifdef HAS_IGNITION_PLUGIN
   for (auto& scenario : scenarios)
     scenario->clear_scene();
+#endif
 }
 
 void Project::add_lane(
@@ -642,6 +646,7 @@ void Project::add_lane(
   building.add_lane(level_idx, start_idx, end_idx, traffic_map_idx);
 }
 
+#ifdef HAS_IGNITION_PLUGIN
 void Project::scenario_scene_update(
   QGraphicsScene* scene,
   const int level_idx)
@@ -660,6 +665,7 @@ bool Project::has_sim_plugin()
   }
   return false;
 }
+#endif
 
 bool Project::set_filename(const std::string& _fn)
 {

--- a/traffic_editor/gui/project.h
+++ b/traffic_editor/gui/project.h
@@ -120,14 +120,15 @@ public:
     const int start_idx,
     const int end_idx);
 
+#ifdef HAS_IGNITION_PLUGIN
   // simulation stuff
   void sim_reset();
   void sim_tick();
   bool sim_is_paused = true;
+  bool has_sim_plugin();
+#endif
 
   RenderingOptions rendering_options;
-
-  bool has_sim_plugin();
 
   bool set_filename(const std::string& _filename);
   std::string get_filename() { return filename; }

--- a/traffic_editor/gui/scenario.cpp
+++ b/traffic_editor/gui/scenario.cpp
@@ -16,7 +16,10 @@
 */
 
 #include <fstream>
+
+#ifdef HAS_IGNITION_PLUGIN
 #include <ignition/common/SystemPaths.hh>
+#endif
 
 #include "scenario.h"
 #include "yaml_utils.h"
@@ -62,6 +65,7 @@ bool Scenario::load()
     }
   }
 
+#ifdef HAS_IGNITION_PLUGIN
   if (yaml["plugin_name"])
   {
     string plugin_path = yaml["plugin_path"].as<string>();
@@ -112,6 +116,7 @@ bool Scenario::load()
       }
     }
   }
+#endif
 
   print();
 
@@ -201,6 +206,7 @@ bool Scenario::delete_selected(const std::string& level_name)
   return true;
 }
 
+#ifdef HAS_IGNITION_PLUGIN
 void Scenario::sim_tick(Building& building)
 {
   if (!sim_plugin.IsEmpty())
@@ -250,3 +256,4 @@ void Scenario::scene_update(
       sim->scene_update(scene, building, level_idx);
   }
 }
+#endif

--- a/traffic_editor/gui/scenario.h
+++ b/traffic_editor/gui/scenario.h
@@ -25,8 +25,10 @@
 #include "traffic_editor/vertex.h"
 #include "plugins/simulation.h"
 
+#ifdef HAS_IGNITION_PLUGIN
 #include <ignition/plugin/SpecializedPluginPtr.hh>
 #include <ignition/plugin/Loader.hh>
+#endif
 
 #include <map>
 #include <memory>
@@ -80,7 +82,9 @@ public:
 
   std::vector<std::string> behavior_signals;
 
+#ifdef HAS_IGNITION_PLUGIN
   ignition::plugin::SpecializedPluginPtr<Simulation> sim_plugin;
+#endif
 };
 
 #endif


### PR DESCRIPTION
This PR adds a bit of CMake logic and some `#ifdef` throughout the code so that it doesn't compile support for "traffic-editor simulation" plugins if `libignition-plugin` is not present. This will remove the previous hard dependency on `ignition-plugin` and make it a soft dependency, and since nobody is currently using that plugin interface, that seems like a good tradeoff. Hopefully now it will become possible to release this package as a binary, using the normal ROS package release flow.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>