### PR TITLE
Uncommented code block which saves lift parameters when OK is clicked, added initial_floor_name

### DIFF
--- a/traffic_editor/gui/lift_dialog.cpp
+++ b/traffic_editor/gui/lift_dialog.cpp
@@ -348,12 +348,14 @@ void LiftDialog::ok_button_clicked()
     QMessageBox::critical(this, "Error", "Lowest floor above highest floor");
     return;
   }
-  /*
+  
   _lift.name = _name_line_edit->text().toStdString();
   _lift.reference_floor_name =
     _reference_floor_combo_box->currentText().toStdString();
   _lift.highest_floor = _highest_floor_combo_box->currentText().toStdString();
   _lift.lowest_floor = _lowest_floor_combo_box->currentText().toStdString();
+  _lift.initial_floor_name =
+    _initial_floor_combo_box->currentText().toStdString();
 
   _lift.x = _x_line_edit->text().toDouble();
   _lift.y = _y_line_edit->text().toDouble();
@@ -361,7 +363,7 @@ void LiftDialog::ok_button_clicked()
 
   _lift.width = _width_line_edit->text().toDouble();
   _lift.depth = _depth_line_edit->text().toDouble();
-  */
+  
   // grab all the level-door checkbox matrix states and save them
   for (int level_row = 0; level_row < _level_table->rowCount(); level_row++)
   {

--- a/traffic_editor/gui/lift_dialog.cpp
+++ b/traffic_editor/gui/lift_dialog.cpp
@@ -348,7 +348,7 @@ void LiftDialog::ok_button_clicked()
     QMessageBox::critical(this, "Error", "Lowest floor above highest floor");
     return;
   }
-  
+
   _lift.name = _name_line_edit->text().toStdString();
   _lift.reference_floor_name =
     _reference_floor_combo_box->currentText().toStdString();
@@ -363,7 +363,7 @@ void LiftDialog::ok_button_clicked()
 
   _lift.width = _width_line_edit->text().toDouble();
   _lift.depth = _depth_line_edit->text().toDouble();
-  
+
   // grab all the level-door checkbox matrix states and save them
   for (int level_row = 0; level_row < _level_table->rowCount(); level_row++)
   {


### PR DESCRIPTION
* Bug occurs when default values in combo boxes are used, therefore nothing gets saved into the lift's internal states. The only saving mechanism was left to the `onTextChanged` signal
* Solves https://github.com/osrf/traffic_editor/issues/247