### PR TITLE
Fix xml namespace not appearing in generated world files

### DIFF
--- a/building_map_tools/building_map/building.py
+++ b/building_map_tools/building_map/building.py
@@ -200,7 +200,10 @@ class Building:
         tree = parse(template_path)
         sdf = tree.getroot()
 
+        xmlns = {'name': 'rmf', 'value': 'rmf'}  # For any custom elements
+
         world = sdf.find('world')
+        world.attrib['xmlns:' + xmlns['name']] = xmlns['value']
 
         for level_name, level in self.levels.items():
             level.generate_sdf_models(world)  # todo: a better name
@@ -224,7 +227,7 @@ class Building:
 
         charger_waypoints_ele = SubElement(
           world,
-          'rmf:charger_waypoints',
+          xmlns['name'] + ':charger_waypoints',
           {'name': 'charger_waypoints'})
 
         for level_name, level in self.levels.items():
@@ -232,7 +235,7 @@ class Building:
                 if 'is_charger' in vertex.params:
                     SubElement(
                       charger_waypoints_ele,
-                      'rmf:vertex',
+                      xmlns['name'] + ':vertex',
                       {'name': vertex.name, 'x': str(vertex.x),
                        'y': str(vertex.y), 'level': level_name})
 

--- a/building_map_tools/building_map/templates/gz_world.sdf
+++ b/building_map_tools/building_map/templates/gz_world.sdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdf version="1.7">
-  <world name="world" xmlns:rmf="rmf">
+  <world name="world">
     <scene>
       <ambient>0.8 0.8 0.8 1.0</ambient>
       <background>0 0 0</background>

--- a/building_map_tools/building_map/templates/ign_world.sdf
+++ b/building_map_tools/building_map/templates/ign_world.sdf
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdf version="1.7">
-  <world name="sim_world" xmlns:rmf="rmf">
+  <world name="sim_world">
     <physics name="1ms" type="ode">
       <max_step_size>0.001</max_step_size>
       <real_time_factor>1.0</real_time_factor>


### PR DESCRIPTION
ElementTree's `parse()` method does not store the `xmlns` attribute as part of an element's `attrib` dict, which means
it gets ignored when the template file is parsed and a new world file is generated. This PR inserts the xmlns attribute where
appropriate during the world sdf file generation, since the namespace is only needed for particular elements anyway.

Fixes #246
