### PR TITLE
Fixed RobotMode

### DIFF
--- a/building_sim_plugins/building_plugins_common/include/building_sim_common/slotcar_common.hpp
+++ b/building_sim_plugins/building_plugins_common/include/building_sim_common/slotcar_common.hpp
@@ -242,6 +242,8 @@ private:
   // Straight line distance to charging waypoint within which charging can occur
   static constexpr double _charger_dist_thres = 0.2;
 
+  bool _docking = false;
+
   std::string get_level_name(const double z) const;
 
   double compute_change_in_rotation(Eigen::Vector3d heading_vec,

--- a/building_sim_plugins/building_plugins_common/src/slotcar_common.cpp
+++ b/building_sim_plugins/building_plugins_common/src/slotcar_common.cpp
@@ -312,6 +312,10 @@ std::pair<double, double> SlotcarCommon::update(const Eigen::Isometry3d& pose,
     {
       _current_mode.mode = rmf_fleet_msgs::msg::RobotMode::MODE_CHARGING;
     }
+    else if (_docking)
+    {
+      _current_mode.mode = rmf_fleet_msgs::msg::RobotMode::MODE_DOCKING;
+    }
     else
     {
       _current_mode.mode = rmf_fleet_msgs::msg::RobotMode::MODE_MOVING;
@@ -563,6 +567,10 @@ void SlotcarCommon::mode_request_cb(
   const rmf_fleet_msgs::msg::ModeRequest::SharedPtr msg)
 {
   _current_mode = msg->mode;
+  if (msg->mode.mode == msg->mode.MODE_DOCKING)
+    _docking = true;
+  else
+    _docking = false;
 }
 
 void SlotcarCommon::map_cb(


### PR DESCRIPTION
This PR ensures that the RobotMode in the RobotState message published by the slotcar remains as `MODE_DOCKING` until another ModeRequest is received. 