### PR TITLE
Fix namespace for rmf charging plugin

### DIFF
--- a/building_map_tools/building_map/building.py
+++ b/building_map_tools/building_map/building.py
@@ -224,7 +224,7 @@ class Building:
 
         charger_waypoints_ele = SubElement(
           world,
-          'rmf:charger_waypoints',
+          'rmf_charger_waypoints',
           {'name': 'charger_waypoints'})
 
         for level_name, level in self.levels.items():
@@ -232,7 +232,7 @@ class Building:
                 if 'is_charger' in vertex.params:
                     SubElement(
                       charger_waypoints_ele,
-                      'rmf:vertex',
+                      'rmf_vertex',
                       {'name': vertex.name, 'x': str(vertex.x),
                        'y': str(vertex.y), 'level': level_name})
 

--- a/building_sim_plugins/building_plugins_common/include/building_sim_common/slotcar_common.hpp
+++ b/building_sim_plugins/building_plugins_common/include/building_sim_common/slotcar_common.hpp
@@ -382,12 +382,12 @@ void SlotcarCommon::read_sdf(SdfPtrT& sdf)
   if (sdf->GetParent() && sdf->GetParent()->GetParent())
   {
     auto parent = sdf->GetParent()->GetParent();
-    if (parent->HasElement("rmf:charger_waypoints"))
+    if (parent->HasElement("rmf_charger_waypoints"))
     {
-      auto waypoints = parent->GetElement("rmf:charger_waypoints");
-      if (waypoints->HasElement("rmf:vertex"))
+      auto waypoints = parent->GetElement("rmf_charger_waypoints");
+      if (waypoints->HasElement("rmf_vertex"))
       {
-        auto waypoint = waypoints->GetElement("rmf:vertex");
+        auto waypoint = waypoints->GetElement("rmf_vertex");
         while (waypoint)
         {
           if (waypoint->HasAttribute("x") && waypoint->HasAttribute("y") &&
@@ -400,7 +400,7 @@ void SlotcarCommon::read_sdf(SdfPtrT& sdf)
             waypoint->GetAttribute("level")->Get(lvl_name);
             _charger_waypoints[lvl_name].push_back(ChargerWaypoint(x, y));
           }
-          waypoint = waypoint->GetNextElement("rmf:vertex");
+          waypoint = waypoint->GetNextElement("rmf_vertex");
         }
       }
     }


### PR DESCRIPTION
Using colons for in tags creates issues when parsing XML files in Python, since the colon implements namespaces in the specification, for example while parsing a world I got the following error:

```
xml.etree.ElementTree.ParseError: unbound prefix: line 5819, column 4
```

Changing them to underscore fixes the issue.