### PR TITLE
Determine slotcar target heading by proximity to the commanded heading in its trajectory

### DIFF
--- a/building_sim_plugins/building_plugins_common/include/building_sim_common/slotcar_common.hpp
+++ b/building_sim_plugins/building_plugins_common/include/building_sim_common/slotcar_common.hpp
@@ -244,9 +244,11 @@ private:
 
   std::string get_level_name(const double z) const;
 
-  double compute_change_in_rotation(Eigen::Vector3d heading_vec,
+  double compute_change_in_rotation(
+    const Eigen::Vector3d& heading_vec,
     const Eigen::Vector3d& dpos,
-    double* permissive = nullptr);
+    const Eigen::Vector3d* traj_vec = nullptr,
+    double* const dir = nullptr) const;
 
   void publish_tf2(const rclcpp::Time& t);
 


### PR DESCRIPTION
Modifies `compute_change_in_rotation` to choose a heading based on proximity to the commanded heading
in the slotcar's trajectory, instead of choosing a heading based off of the amount of rotation required.