### PR TITLE
Feature/remove plugin option

### DIFF
--- a/building_map_tools/building_map/doors/door.py
+++ b/building_map_tools/building_map/doors/door.py
@@ -6,6 +6,7 @@ class Door:
     def __init__(self, door_edge, level_elevation=0.0):
         self.name = door_edge.params['name'].value
         self.type = door_edge.params['type'].value
+        self.remove_plugin = door_edge.params['remove_plugin'].value
         self.length = door_edge.length
         self.cx = door_edge.x
         self.cy = door_edge.y

--- a/building_map_tools/building_map/doors/door.py
+++ b/building_map_tools/building_map/doors/door.py
@@ -6,7 +6,7 @@ class Door:
     def __init__(self, door_edge, level_elevation=0.0):
         self.name = door_edge.params['name'].value
         self.type = door_edge.params['type'].value
-        self.remove_plugin = door_edge.params['remove_plugin'].value
+        self.plugin = door_edge.params['plugin'].value
         self.length = door_edge.length
         self.cx = door_edge.x
         self.cy = door_edge.y

--- a/building_map_tools/building_map/doors/door.py
+++ b/building_map_tools/building_map/doors/door.py
@@ -21,6 +21,10 @@ class Door:
         pose_ele = SubElement(self.model_ele, 'pose')
         pose_ele.text = f'{self.cx} {self.cy} {self.cz} 0 0 {self.yaw}'
 
+        if self.plugin == 'none':
+            static_ele = SubElement(self.model_ele, 'static')
+            static_ele.text = 'true'
+
     def generate_section(self, name, width, x_offset, options):
         pose_ele = Element('pose')
         pose_ele.text = f'{x_offset} 0 {self.height/2+0.01} 0 0 0'

--- a/building_map_tools/building_map/doors/double_sliding_door.py
+++ b/building_map_tools/building_map/doors/double_sliding_door.py
@@ -21,7 +21,7 @@ class DoubleSlidingDoor(Door):
             (0.0, self.length/2),
             options)
 
-        if not self.remove_plugin:
+        if not self.plugin == 'none':
             plugin_ele = SubElement(self.model_ele, 'plugin')
             plugin_ele.set('name', 'door')
             plugin_ele.set('filename', 'libdoor.so')

--- a/building_map_tools/building_map/doors/double_sliding_door.py
+++ b/building_map_tools/building_map/doors/double_sliding_door.py
@@ -21,24 +21,25 @@ class DoubleSlidingDoor(Door):
             (0.0, self.length/2),
             options)
 
-        plugin_ele = SubElement(self.model_ele, 'plugin')
-        plugin_ele.set('name', 'door')
-        plugin_ele.set('filename', 'libdoor.so')
-        plugin_params = {
-          'v_max_door': '0.2',
-          'a_max_door': '0.2',
-          'a_nom_door': '0.08',
-          'dx_min_door': '0.001',
-          'f_max_door': '100.0'
-        }
-        for param_name, param_value in plugin_params.items():
-            ele = SubElement(plugin_ele, param_name)
-            ele.text = param_value
+        if not self.remove_plugin:
+            plugin_ele = SubElement(self.model_ele, 'plugin')
+            plugin_ele.set('name', 'door')
+            plugin_ele.set('filename', 'libdoor.so')
+            plugin_params = {
+            'v_max_door': '0.2',
+            'a_max_door': '0.2',
+            'a_nom_door': '0.08',
+            'dx_min_door': '0.001',
+            'f_max_door': '100.0'
+            }
+            for param_name, param_value in plugin_params.items():
+                ele = SubElement(plugin_ele, param_name)
+                ele.text = param_value
 
-        door_ele = SubElement(plugin_ele, 'door')
-        door_ele.set('name', self.name)
-        door_ele.set('type', 'DoubleSlidingDoor')
-        door_ele.set('left_joint_name', 'left_joint')
-        door_ele.set('right_joint_name', 'right_joint')
+            door_ele = SubElement(plugin_ele, 'door')
+            door_ele.set('name', self.name)
+            door_ele.set('type', 'DoubleSlidingDoor')
+            door_ele.set('left_joint_name', 'left_joint')
+            door_ele.set('right_joint_name', 'right_joint')
 
         world_ele.append(self.model_ele)

--- a/building_map_tools/building_map/doors/double_sliding_door.py
+++ b/building_map_tools/building_map/doors/double_sliding_door.py
@@ -26,11 +26,11 @@ class DoubleSlidingDoor(Door):
             plugin_ele.set('name', 'door')
             plugin_ele.set('filename', 'libdoor.so')
             plugin_params = {
-            'v_max_door': '0.2',
-            'a_max_door': '0.2',
-            'a_nom_door': '0.08',
-            'dx_min_door': '0.001',
-            'f_max_door': '100.0'
+                'v_max_door': '0.2',
+                'a_max_door': '0.2',
+                'a_nom_door': '0.08',
+                'dx_min_door': '0.001',
+                'f_max_door': '100.0'
             }
             for param_name, param_value in plugin_params.items():
                 ele = SubElement(plugin_ele, param_name)

--- a/building_map_tools/building_map/doors/double_swing_door.py
+++ b/building_map_tools/building_map/doors/double_swing_door.py
@@ -31,7 +31,7 @@ class DoubleSwingDoor(Door):
             (x_flip_sign * self.length / 4, 0, 0),
             options)
 
-        if not self.remove_plugin:
+        if not self.plugin == 'none':
             plugin_ele = SubElement(self.model_ele, 'plugin')
             plugin_ele.set('name', 'door')
             plugin_ele.set('filename', 'libdoor.so')

--- a/building_map_tools/building_map/doors/double_swing_door.py
+++ b/building_map_tools/building_map/doors/double_swing_door.py
@@ -36,11 +36,11 @@ class DoubleSwingDoor(Door):
             plugin_ele.set('name', 'door')
             plugin_ele.set('filename', 'libdoor.so')
             plugin_params = {
-            'v_max_door': '0.5',
-            'a_max_door': '0.3',
-            'a_nom_door': '0.15',
-            'dx_min_door': '0.01',
-            'f_max_door': '500.0'
+                'v_max_door': '0.5',
+                'a_max_door': '0.3',
+                'a_nom_door': '0.15',
+                'dx_min_door': '0.01',
+                'f_max_door': '500.0'
             }
             for param_name, param_value in plugin_params.items():
                 ele = SubElement(plugin_ele, param_name)

--- a/building_map_tools/building_map/doors/double_swing_door.py
+++ b/building_map_tools/building_map/doors/double_swing_door.py
@@ -31,24 +31,25 @@ class DoubleSwingDoor(Door):
             (x_flip_sign * self.length / 4, 0, 0),
             options)
 
-        plugin_ele = SubElement(self.model_ele, 'plugin')
-        plugin_ele.set('name', 'door')
-        plugin_ele.set('filename', 'libdoor.so')
-        plugin_params = {
-          'v_max_door': '0.5',
-          'a_max_door': '0.3',
-          'a_nom_door': '0.15',
-          'dx_min_door': '0.01',
-          'f_max_door': '500.0'
-        }
-        for param_name, param_value in plugin_params.items():
-            ele = SubElement(plugin_ele, param_name)
-            ele.text = param_value
+        if not self.remove_plugin:
+            plugin_ele = SubElement(self.model_ele, 'plugin')
+            plugin_ele.set('name', 'door')
+            plugin_ele.set('filename', 'libdoor.so')
+            plugin_params = {
+            'v_max_door': '0.5',
+            'a_max_door': '0.3',
+            'a_nom_door': '0.15',
+            'dx_min_door': '0.01',
+            'f_max_door': '500.0'
+            }
+            for param_name, param_value in plugin_params.items():
+                ele = SubElement(plugin_ele, param_name)
+                ele.text = param_value
 
-        door_ele = SubElement(plugin_ele, 'door')
-        door_ele.set('name', self.name)
-        door_ele.set('type', 'DoubleSwingDoor')
-        door_ele.set('left_joint_name', 'left_joint')
-        door_ele.set('right_joint_name', 'right_joint')
+            door_ele = SubElement(plugin_ele, 'door')
+            door_ele.set('name', self.name)
+            door_ele.set('type', 'DoubleSwingDoor')
+            door_ele.set('left_joint_name', 'left_joint')
+            door_ele.set('right_joint_name', 'right_joint')
 
         world_ele.append(self.model_ele)

--- a/building_map_tools/building_map/doors/sliding_door.py
+++ b/building_map_tools/building_map/doors/sliding_door.py
@@ -14,7 +14,7 @@ class SlidingDoor(Door):
             (0.0, self.length),
             options)
 
-        if not self.remove_plugin:
+        if not self.plugin == 'none':
             plugin_ele = SubElement(self.model_ele, 'plugin')
             plugin_ele.set('name', 'door')
             plugin_ele.set('filename', 'libdoor.so')

--- a/building_map_tools/building_map/doors/sliding_door.py
+++ b/building_map_tools/building_map/doors/sliding_door.py
@@ -19,11 +19,11 @@ class SlidingDoor(Door):
             plugin_ele.set('name', 'door')
             plugin_ele.set('filename', 'libdoor.so')
             plugin_params = {
-            'v_max_door': '0.2',
-            'a_max_door': '0.2',
-            'a_nom_door': '0.08',
-            'dx_min_door': '0.001',
-            'f_max_door': '100.0'
+                'v_max_door': '0.2',
+                'a_max_door': '0.2',
+                'a_nom_door': '0.08',
+                'dx_min_door': '0.001',
+                'f_max_door': '100.0'
             }
             for param_name, param_value in plugin_params.items():
                 ele = SubElement(plugin_ele, param_name)

--- a/building_map_tools/building_map/doors/sliding_door.py
+++ b/building_map_tools/building_map/doors/sliding_door.py
@@ -14,24 +14,25 @@ class SlidingDoor(Door):
             (0.0, self.length),
             options)
 
-        plugin_ele = SubElement(self.model_ele, 'plugin')
-        plugin_ele.set('name', 'door')
-        plugin_ele.set('filename', 'libdoor.so')
-        plugin_params = {
-          'v_max_door': '0.2',
-          'a_max_door': '0.2',
-          'a_nom_door': '0.08',
-          'dx_min_door': '0.001',
-          'f_max_door': '100.0'
-        }
-        for param_name, param_value in plugin_params.items():
-            ele = SubElement(plugin_ele, param_name)
-            ele.text = param_value
+        if not self.remove_plugin:
+            plugin_ele = SubElement(self.model_ele, 'plugin')
+            plugin_ele.set('name', 'door')
+            plugin_ele.set('filename', 'libdoor.so')
+            plugin_params = {
+            'v_max_door': '0.2',
+            'a_max_door': '0.2',
+            'a_nom_door': '0.08',
+            'dx_min_door': '0.001',
+            'f_max_door': '100.0'
+            }
+            for param_name, param_value in plugin_params.items():
+                ele = SubElement(plugin_ele, param_name)
+                ele.text = param_value
 
-        door_ele = SubElement(plugin_ele, 'door')
-        door_ele.set('name', self.name)
-        door_ele.set('type', 'SlidingDoor')
-        door_ele.set('left_joint_name', 'empty_joint')
-        door_ele.set('right_joint_name', 'right_joint')
+            door_ele = SubElement(plugin_ele, 'door')
+            door_ele.set('name', self.name)
+            door_ele.set('type', 'SlidingDoor')
+            door_ele.set('left_joint_name', 'empty_joint')
+            door_ele.set('right_joint_name', 'right_joint')
 
         world_ele.append(self.model_ele)

--- a/building_map_tools/building_map/doors/swing_door.py
+++ b/building_map_tools/building_map/doors/swing_door.py
@@ -10,23 +10,25 @@ class SwingDoor(Door):
         self.motion_direction = door_edge.params['motion_direction'].value
 
     def generate(self, world_ele, options):
-        plugin_ele = SubElement(self.model_ele, 'plugin')
-        plugin_ele.set('name', 'door')
-        plugin_ele.set('filename', 'libdoor.so')
-        plugin_params = {
-          'v_max_door': '0.5',
-          'a_max_door': '0.3',
-          'a_nom_door': '0.15',
-          'dx_min_door': '0.01',
-          'f_max_door': '500.0'
-        }
-        for param_name, param_value in plugin_params.items():
-            ele = SubElement(plugin_ele, param_name)
-            ele.text = param_value
+        door_ele = None
+        if not self.remove_plugin:
+            plugin_ele = SubElement(self.model_ele, 'plugin')
+            plugin_ele.set('name', 'door')
+            plugin_ele.set('filename', 'libdoor.so')
+            plugin_params = {
+            'v_max_door': '0.5',
+            'a_max_door': '0.3',
+            'a_nom_door': '0.15',
+            'dx_min_door': '0.01',
+            'f_max_door': '500.0'
+            }
+            for param_name, param_value in plugin_params.items():
+                ele = SubElement(plugin_ele, param_name)
+                ele.text = param_value
 
-        door_ele = SubElement(plugin_ele, 'door')
-        door_ele.set('name', self.name)
-        door_ele.set('type', 'SwingDoor')
+            door_ele = SubElement(plugin_ele, 'door')
+            door_ele.set('name', self.name)
+            door_ele.set('type', 'SwingDoor')
 
         if self.motion_direction > 0:
             self.generate_swing_section(
@@ -36,8 +38,9 @@ class SwingDoor(Door):
                 (-self.motion_radians, 0),
                 (self.length / 2, 0, 0),
                 options)
-            door_ele.set('left_joint_name', 'left_joint')
-            door_ele.set('right_joint_name', 'empty_joint')
+            if door_ele:
+                door_ele.set('left_joint_name', 'left_joint')
+                door_ele.set('right_joint_name', 'empty_joint')
         else:
             self.generate_swing_section(
                 'right',
@@ -46,7 +49,8 @@ class SwingDoor(Door):
                 (0, self.motion_radians),
                 (self.length / 2, 0, 0),
                 options)
-            door_ele.set('left_joint_name', 'empty_joint')
-            door_ele.set('right_joint_name', 'right_joint')
+            if door_ele:
+                door_ele.set('left_joint_name', 'empty_joint')
+                door_ele.set('right_joint_name', 'right_joint')
 
         world_ele.append(self.model_ele)

--- a/building_map_tools/building_map/doors/swing_door.py
+++ b/building_map_tools/building_map/doors/swing_door.py
@@ -16,11 +16,11 @@ class SwingDoor(Door):
             plugin_ele.set('name', 'door')
             plugin_ele.set('filename', 'libdoor.so')
             plugin_params = {
-            'v_max_door': '0.5',
-            'a_max_door': '0.3',
-            'a_nom_door': '0.15',
-            'dx_min_door': '0.01',
-            'f_max_door': '500.0'
+                'v_max_door': '0.5',
+                'a_max_door': '0.3',
+                'a_nom_door': '0.15',
+                'dx_min_door': '0.01',
+                'f_max_door': '500.0'
             }
             for param_name, param_value in plugin_params.items():
                 ele = SubElement(plugin_ele, param_name)

--- a/building_map_tools/building_map/doors/swing_door.py
+++ b/building_map_tools/building_map/doors/swing_door.py
@@ -11,7 +11,7 @@ class SwingDoor(Door):
 
     def generate(self, world_ele, options):
         door_ele = None
-        if not self.remove_plugin:
+        if not self.plugin == 'none':
             plugin_ele = SubElement(self.model_ele, 'plugin')
             plugin_ele.set('name', 'door')
             plugin_ele.set('filename', 'libdoor.so')
@@ -38,7 +38,7 @@ class SwingDoor(Door):
                 (-self.motion_radians, 0),
                 (self.length / 2, 0, 0),
                 options)
-            if door_ele:
+            if door_ele is not None:
                 door_ele.set('left_joint_name', 'left_joint')
                 door_ele.set('right_joint_name', 'empty_joint')
         else:
@@ -49,7 +49,7 @@ class SwingDoor(Door):
                 (0, self.motion_radians),
                 (self.length / 2, 0, 0),
                 options)
-            if door_ele:
+            if door_ele is not None:
                 door_ele.set('left_joint_name', 'empty_joint')
                 door_ele.set('right_joint_name', 'right_joint')
 

--- a/building_map_tools/building_map/lift.py
+++ b/building_map_tools/building_map/lift.py
@@ -186,17 +186,18 @@ class LiftDoor:
                                     lower_limit=-self.width / 2,
                                     upper_limit=0))
 
-        plugin_ele = SubElement(lift_model_ele, 'plugin')
-        plugin_ele.set('name', 'door')
-        plugin_ele.set('filename', 'libdoor.so')
-        for param_name, param_value in self.params.items():
-            ele = SubElement(plugin_ele, param_name)
-            ele.text = f'{param_value}'
-        door_ele = SubElement(plugin_ele, 'door')
-        door_ele.set('left_joint_name', f'{name}_left_joint')
-        door_ele.set('name', f'{name}')
-        door_ele.set('right_joint_name', f'{name}_right_joint')
-        door_ele.set('type', 'DoubleSlidingDoor')
+        if self.plugin:
+            plugin_ele = SubElement(lift_model_ele, 'plugin')
+            plugin_ele.set('name', 'door')
+            plugin_ele.set('filename', 'libdoor.so')
+            for param_name, param_value in self.params.items():
+                ele = SubElement(plugin_ele, param_name)
+                ele.text = f'{param_value}'
+            door_ele = SubElement(plugin_ele, 'door')
+            door_ele.set('left_joint_name', f'{name}_left_joint')
+            door_ele.set('name', f'{name}')
+            door_ele.set('right_joint_name', f'{name}_right_joint')
+            door_ele.set('type', 'DoubleSlidingDoor')
 
 
 class Lift:
@@ -290,7 +291,8 @@ class Lift:
             doors.append(LiftDoor(lift_door_yaml,
                                   lift_door_name,
                                   (self.width, self.depth, self.cabin_height),
-                                  self.gap))
+                                  self.gap,
+                                  self.plugins))
         return doors
 
     def get_lift_vertices(self):

--- a/building_map_tools/building_map/lift.py
+++ b/building_map_tools/building_map/lift.py
@@ -431,6 +431,9 @@ class Lift:
 
             cabin_joint_ele = SubElement(plugin_ele, 'cabin_joint_name')
             cabin_joint_ele.text = 'cabin_joint'
+        else:
+            static_lift_ele = SubElement(lift_model_ele, 'static')
+            static_lift_ele.text = 'true'
 
         # pose
         model_pose = SubElement(lift_model_ele, 'pose')

--- a/building_map_tools/building_map/lift.py
+++ b/building_map_tools/building_map/lift.py
@@ -412,7 +412,8 @@ class Lift:
             for level_name, door_names in self.level_doors.items():
                 floor_ele = SubElement(plugin_ele, 'floor')
                 floor_ele.set('name', f'{level_name}')
-                floor_ele.set('elevation', f'{self.level_elevation[level_name]}')
+                floor_ele.set(
+                    'elevation', f'{self.level_elevation[level_name]}')
                 for door in self.doors:
                     if door.name in door_names:
                         door_pair_ele = SubElement(floor_ele, 'door_pair')

--- a/traffic_editor/gui/edge.cpp
+++ b/traffic_editor/gui/edge.cpp
@@ -136,6 +136,7 @@ void Edge::create_required_parameters()
     create_param_if_needed("motion_axis", Param::STRING, std::string("start"));
     create_param_if_needed("motion_direction", Param::INT, 1);
     create_param_if_needed("motion_degrees", Param::DOUBLE, 90.0);  // hinged
+    create_param_if_needed("remove_plugin", Param::BOOL, false);
   }
   else if (type == HUMAN_LANE)
   {

--- a/traffic_editor/gui/edge.cpp
+++ b/traffic_editor/gui/edge.cpp
@@ -136,7 +136,7 @@ void Edge::create_required_parameters()
     create_param_if_needed("motion_axis", Param::STRING, std::string("start"));
     create_param_if_needed("motion_direction", Param::INT, 1);
     create_param_if_needed("motion_degrees", Param::DOUBLE, 90.0);  // hinged
-    create_param_if_needed("remove_plugin", Param::BOOL, false);
+    create_param_if_needed("plugin", Param::STRING, std::string("normal"));
   }
   else if (type == HUMAN_LANE)
   {

--- a/traffic_editor/gui/lift.cpp
+++ b/traffic_editor/gui/lift.cpp
@@ -45,6 +45,7 @@ void Lift::from_yaml(const std::string& _name, const YAML::Node& data,
     initial_floor_name = reference_floor_name;
   width = data["width"].as<double>();
   depth = data["depth"].as<double>();
+  plugins = data["plugins"].as<bool>();
 
   if (data["doors"] && data["doors"].IsMap())
   {
@@ -105,6 +106,7 @@ YAML::Node Lift::to_yaml() const
   n["initial_floor_name"] = initial_floor_name;
   n["width"] = std::round(width * 1000.0) / 1000.0;
   n["depth"] = std::round(depth * 1000.0) / 1000.0;
+  n["plugins"] = plugins;
 
   n["doors"] = YAML::Node(YAML::NodeType::Map);
   for (const auto& door : doors)

--- a/traffic_editor/gui/lift_dialog.cpp
+++ b/traffic_editor/gui/lift_dialog.cpp
@@ -231,6 +231,14 @@ LiftDialog::LiftDialog(Lift& lift, Building& building)
     });
   depth_hbox->addWidget(_depth_line_edit);
 
+  QHBoxLayout* plugin_hbox = new QHBoxLayout;
+  plugin_hbox->addWidget(new QLabel("Plugin:"));
+  _plugin_yes_radio_button = new QRadioButton("Yes");
+  _plugin_yes_radio_button->setChecked(true);
+  _plugin_no_radio_button = new QRadioButton("No");
+  plugin_hbox->addWidget(_plugin_yes_radio_button);
+  plugin_hbox->addWidget(_plugin_no_radio_button);
+
   QHBoxLayout* add_wp_hbox = new QHBoxLayout;
   _add_wp_button = new QPushButton("Add lift waypoints", this);
   add_wp_hbox->addWidget(_add_wp_button);
@@ -293,6 +301,7 @@ LiftDialog::LiftDialog(Lift& lift, Building& building)
   left_vbox->addLayout(yaw_hbox);
   left_vbox->addLayout(width_hbox);
   left_vbox->addLayout(depth_hbox);
+  left_vbox->addLayout(plugin_hbox);
   left_vbox->addLayout(add_wp_hbox);
   left_vbox->addWidget(_level_table);
 
@@ -363,6 +372,20 @@ void LiftDialog::ok_button_clicked()
 
   _lift.width = _width_line_edit->text().toDouble();
   _lift.depth = _depth_line_edit->text().toDouble();
+
+  if (_plugin_yes_radio_button->isChecked())
+  {
+    _lift.plugins = true;
+    for (const auto& d : _lift.doors)
+    {
+      d.plugin = true;
+    }
+  }
+  else if (_plugin_no_radio_button->isChecked())
+  {
+    _lift.plugins = false;
+    d.plugin = false;
+  }
 
   // grab all the level-door checkbox matrix states and save them
   for (int level_row = 0; level_row < _level_table->rowCount(); level_row++)

--- a/traffic_editor/gui/lift_dialog.cpp
+++ b/traffic_editor/gui/lift_dialog.cpp
@@ -234,8 +234,12 @@ LiftDialog::LiftDialog(Lift& lift, Building& building)
   QHBoxLayout* plugin_hbox = new QHBoxLayout;
   plugin_hbox->addWidget(new QLabel("Plugin:"));
   _plugin_yes_radio_button = new QRadioButton("Yes");
-  _plugin_yes_radio_button->setChecked(true);
   _plugin_no_radio_button = new QRadioButton("No");
+  if (_lift.plugins)
+    _plugin_yes_radio_button->setChecked(true);
+  else
+    _plugin_no_radio_button->setChecked(true);
+
   plugin_hbox->addWidget(_plugin_yes_radio_button);
   plugin_hbox->addWidget(_plugin_no_radio_button);
 
@@ -374,18 +378,9 @@ void LiftDialog::ok_button_clicked()
   _lift.depth = _depth_line_edit->text().toDouble();
 
   if (_plugin_yes_radio_button->isChecked())
-  {
     _lift.plugins = true;
-    for (const auto& d : _lift.doors)
-    {
-      d.plugin = true;
-    }
-  }
   else if (_plugin_no_radio_button->isChecked())
-  {
     _lift.plugins = false;
-    d.plugin = false;
-  }
 
   // grab all the level-door checkbox matrix states and save them
   for (int level_row = 0; level_row < _level_table->rowCount(); level_row++)

--- a/traffic_editor/gui/lift_dialog.h
+++ b/traffic_editor/gui/lift_dialog.h
@@ -22,6 +22,7 @@
 
 #include <QDialog>
 #include <QObject>
+#include <QRadioButton>
 
 #include "traffic_editor/lift.h"
 #include "traffic_editor/building.h"
@@ -56,6 +57,8 @@ private:
   QLineEdit* _yaw_line_edit;
   QLineEdit* _width_line_edit;
   QLineEdit* _depth_line_edit;
+  QRadioButton* _plugin_yes_radio_button;
+  QRadioButton* _plugin_no_radio_button;
 
   QTableWidget* _door_table;
   QTableWidget* _level_table;

--- a/traffic_editor/include/traffic_editor/lift.h
+++ b/traffic_editor/include/traffic_editor/lift.h
@@ -70,6 +70,12 @@ public:
   typedef std::map<std::string, DoorNameList> LevelDoorMap;
   LevelDoorMap level_doors;
 
+  // When this option is false, it indicates that a lift plugin and its lift
+  // door plugins should not be included when building the simulation world.
+  // This will help speed up the simulation as well as represent lifts that are
+  // not accessible by AGVs.
+  bool plugins = true;
+
   ////////////////////////////////////////////////////////////////////////
 
   Lift();


### PR DESCRIPTION
* Door edges now have a plugin parameter, which can be selected as `normal` or `none`, this will include or remove the plugin tags when generating the door in the `.world` file
* Lifts have radio buttons to choose whether plugins are required as well, similarly it is read to determine whether plugins are required
* When lifts are selected to not have plugins, the lift models will be set to static.