### PR TITLE
Fix door, lift plugin disable options backwards compatibility

### DIFF
--- a/building_map_tools/building_map/doors/door.py
+++ b/building_map_tools/building_map/doors/door.py
@@ -6,7 +6,11 @@ class Door:
     def __init__(self, door_edge, level_elevation=0.0):
         self.name = door_edge.params['name'].value
         self.type = door_edge.params['type'].value
-        self.plugin = door_edge.params['plugin'].value
+        if 'plugin' in door_edge.params:
+            self.plugin = door_edge.params['plugin'].value
+        else:
+            self.plugin = 'normal'
+
         self.length = door_edge.length
         self.cx = door_edge.x
         self.cy = door_edge.y

--- a/traffic_editor/gui/lift.cpp
+++ b/traffic_editor/gui/lift.cpp
@@ -45,7 +45,10 @@ void Lift::from_yaml(const std::string& _name, const YAML::Node& data,
     initial_floor_name = reference_floor_name;
   width = data["width"].as<double>();
   depth = data["depth"].as<double>();
-  plugins = data["plugins"].as<bool>();
+  if (data["plugins"])
+    plugins = data["plugins"].as<bool>();
+  else
+    plugins = true;
 
   if (data["doors"] && data["doors"].IsMap())
   {


### PR DESCRIPTION
Signed-off-by: Chen Bainian <chenbn@artc.a-star.edu.sg>

I really love the new plugin disable feature. Here are some changes I made that should make the old yaml files backwards compatible.

This should resolve
- `test_map` **door** not building due to missing 'plugin' argument
- old map yaml unable to open in traffic editor due to missing 'plugins' bool field for **lift**

Also this should fix https://github.com/osrf/rmf_demos/issues/157