### PR TITLE
check crowd sim impl pointer before deref

### DIFF
--- a/traffic_editor/gui/building.cpp
+++ b/traffic_editor/gui/building.cpp
@@ -156,7 +156,8 @@ bool Building::save_yaml_file()
   for (const auto& lift : lifts)
     y["lifts"][lift.name] = lift.to_yaml();
 
-  y["crowd_sim"] = crowd_sim_impl->to_yaml();
+  if (crowd_sim_impl == nullptr)
+    y["crowd_sim"] = crowd_sim_impl->to_yaml();
 
   YAML::Emitter emitter;
   yaml_utils::write_node(y, emitter);


### PR DESCRIPTION
During new project creation, the `crowd_sim_impl` pointer will be `nullptr` so the automatic save during creation explodes. This one-liner makes it not explode.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>