### PR TITLE
fix to compilation when no opencv

### DIFF
--- a/traffic_editor/gui/editor.h
+++ b/traffic_editor/gui/editor.h
@@ -249,6 +249,8 @@ private:
   void sim_reset();
   void sim_play_pause();
   SimThread sim_thread;
+  QTimer* scene_update_timer;
+  void scene_update_timer_timeout();
 #endif
 
 public:
@@ -262,8 +264,6 @@ private:
   void record_start_stop();
   void record_frame_to_video();
   cv::VideoWriter* video_writer = nullptr;
-  QTimer* scene_update_timer;
-  void scene_update_timer_timeout();
 #endif
 
   std::vector<EditorModel> editor_models;


### PR DESCRIPTION
Traffic_editor wont compile when opencv is not installed but the ignition plugin is there. This will correct the compilation error.