### PR TITLE
Fix undefined initialization of _old_ang_vel and _old_lin_vel

### DIFF
--- a/building_sim_plugins/building_plugins_common/include/building_sim_common/slotcar_common.hpp
+++ b/building_sim_plugins/building_plugins_common/include/building_sim_common/slotcar_common.hpp
@@ -195,8 +195,9 @@ private:
 
   bool _initialized_pose = false; // True if at least 1 call to update() has been made
   Eigen::Isometry3d _old_pose; // Pose at previous time step
-  Eigen::Vector3d _old_lin_vel; // Linear velocity at previous time step
-  double _old_ang_vel; // Angular velocity at previous time step
+  // Assumes robot is stationary upon initialization
+  Eigen::Vector3d _old_lin_vel = Eigen::Vector3d::Zero(); // Linear velocity at previous time step
+  double _old_ang_vel = 0.0; // Angular velocity at previous time step
   Eigen::Isometry3d _pose; // Pose at current time step
   int _rot_dir = 1; // Current direction of rotation
 

--- a/building_sim_plugins/building_plugins_common/src/slotcar_common.cpp
+++ b/building_sim_plugins/building_plugins_common/src/slotcar_common.cpp
@@ -97,10 +97,6 @@ SlotcarCommon::SlotcarCommon()
     .mode_request_id(0)
     .type(rmf_fleet_msgs::msg::PauseRequest::TYPE_RESUME)
     .at_checkpoint(0);
-
-  // Assumes robot is stationary upon initialization
-  _old_lin_vel = Eigen::Vector3d::Zero();
-  _old_ang_vel = 0.0;
 }
 
 rclcpp::Logger SlotcarCommon::logger() const

--- a/building_sim_plugins/building_plugins_common/src/slotcar_common.cpp
+++ b/building_sim_plugins/building_plugins_common/src/slotcar_common.cpp
@@ -97,6 +97,10 @@ SlotcarCommon::SlotcarCommon()
     .mode_request_id(0)
     .type(rmf_fleet_msgs::msg::PauseRequest::TYPE_RESUME)
     .at_checkpoint(0);
+
+  // Assumes robot is stationary upon initialization
+  _old_lin_vel = Eigen::Vector3d::Zero();
+  _old_ang_vel = 0.0;
 }
 
 rclcpp::Logger SlotcarCommon::logger() const


### PR DESCRIPTION
`old_lin_vel` and `old_ang_vel` were not set upon initialization, causing the first iteration of the discharge calculation to output undefined values.