### PR TITLE
scale add-lane vertex snap distance correctly

### DIFF
--- a/traffic_editor/gui/actions/add_edge.cpp
+++ b/traffic_editor/gui/actions/add_edge.cpp
@@ -67,8 +67,8 @@ int AddEdgeCommand::set_first_point(double x, double y)
   _first_y = y;
 
   const double vertex_dist_thresh_pixels =
-      _vertex_radius_meters /
-      _project->building.levels[_level_idx].drawing_meters_per_pixel;
+    _vertex_radius_meters /
+    _project->building.levels[_level_idx].drawing_meters_per_pixel;
 
   int clicked_idx = _project->building.nearest_item_index_if_within_distance(
     _level_idx,
@@ -95,8 +95,8 @@ int AddEdgeCommand::set_second_point(double x, double y)
   _second_y = y;
 
   const double vertex_dist_thresh_pixels =
-      _vertex_radius_meters /
-      _project->building.levels[_level_idx].drawing_meters_per_pixel;
+    _vertex_radius_meters /
+    _project->building.levels[_level_idx].drawing_meters_per_pixel;
 
   int clicked_idx = _project->building.nearest_item_index_if_within_distance(
     _level_idx,

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -1837,9 +1837,18 @@ void Editor::mouse_add_edge(
       return;
     }
 
+    const double vertex_radius_meters = 0.1;
+    const double vertex_dist_thresh =
+      project.building.levels[level_idx].drawing_meters_per_pixel /
+      vertex_radius_meters;
+
     const int prev_clicked_idx = clicked_idx;
     clicked_idx = project.building.nearest_item_index_if_within_distance(
-      level_idx, p_aligned.x(), p_aligned.y(), 10.0, Building::VERTEX);
+      level_idx,
+      p_aligned.x(),
+      p_aligned.y(),
+      vertex_dist_thresh,
+      Building::VERTEX);
 
     if (clicked_idx < 0)
     {

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -1838,16 +1838,16 @@ void Editor::mouse_add_edge(
     }
 
     const double vertex_radius_meters = 0.1;
-    const double vertex_dist_thresh =
-      project.building.levels[level_idx].drawing_meters_per_pixel /
-      vertex_radius_meters;
+    const double vertex_dist_thresh_pixels =
+      vertex_radius_meters /
+      project.building.levels[level_idx].drawing_meters_per_pixel;
 
     const int prev_clicked_idx = clicked_idx;
     clicked_idx = project.building.nearest_item_index_if_within_distance(
       level_idx,
       p_aligned.x(),
       p_aligned.y(),
-      vertex_dist_thresh,
+      vertex_dist_thresh_pixels,
       Building::VERTEX);
 
     if (clicked_idx < 0)


### PR DESCRIPTION
Addresses #275  at least for now, needs to be combined with the Undo work though after that PR is in.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>