### PR TITLE
Modify Ignition door plugin to enable simulations with both TPE and default physics engines

### DIFF
--- a/building_sim_plugins/building_ignition_plugins/src/door.cpp
+++ b/building_sim_plugins/building_ignition_plugins/src/door.cpp
@@ -179,6 +179,7 @@ public:
           ecm.Component<components::Pose>(door_ign.link_entity)->Data()
           + ecm.Component<components::Pose>(_en)->Data();
         door_ign.orig_rotation = door_ign.orig_position.Yaw();
+        door_ign.joint_type = ecm.Component<components::JointType>(door_ign.joint_entity)->Data();
       }
 
       Entity parent = _en;
@@ -216,7 +217,7 @@ public:
           + ecm.Component<components::Pose>(_en)->Data();
         constexpr double eps = 0.01;
 
-        if(door.type == "SwingDoor" || door.type == "DoubleSwingDoor")
+        if (door_ign.joint_type == sdf::JointType::REVOLUTE)
         {
           // In the event that Yaw angle of the door moves past -Pi rads, it experiences
           // a discontinuous jump from -Pi to Pi (vice-versa when the Yaw angle moves past Pi).
@@ -238,7 +239,7 @@ public:
               3.14 + abs(-3.14 - (curr_rot - orig_rot)) : curr_rot - orig_rot;
           }
         }
-        else if(door.type == "SlidingDoor" || door.type == "DoubleSlidingDoor")
+        else if (door_ign.joint_type == sdf::JointType::PRISMATIC)
         {
             ignition::math::Vector3d displacement = curr_pos.CoordPositionSub(orig_pos);
             request.position = displacement.Length();
@@ -279,7 +280,7 @@ public:
         door_ign.vel_cmd = result.velocity;
         double vel_cmd = result.velocity;
         const DoorCommon::DoorElement& door_elem = it->second;
-        if(door_elem.type == "SwingDoor" || door_elem.type == "DoubleSwingDoor")
+        if (door_ign.joint_type == sdf::JointType::REVOLUTE)
         {
           // The reference frame axes of the Linear Velocity Cmds at any point t = axes defined
           // by the link's global pose (link yaw + model yaw) at time t0, rotated by the change in
@@ -312,7 +313,7 @@ public:
           ecm.Component<components::LinearVelocityCmd>(link)->Data() = ignition::math::Vector3d(x_rot_cmd,y_rot_cmd,0);
           ecm.Component<components::AngularVelocityCmd>(link)->Data() = ignition::math::Vector3d(0,0,vel_cmd);
         }
-        else if(door_elem.type == "SlidingDoor" || door_elem.type == "DoubleSlidingDoor")
+        else if (door_ign.joint_type == sdf::JointType::PRISMATIC)
         {
           ecm.Component<components::LinearVelocityCmd>(link)->Data() = ignition::math::Vector3d(vel_cmd,0,0);
         }

--- a/building_sim_plugins/building_ignition_plugins/src/door.cpp
+++ b/building_sim_plugins/building_ignition_plugins/src/door.cpp
@@ -6,6 +6,10 @@
 #include <ignition/gazebo/components/JointPosition.hh>
 #include <ignition/gazebo/components/JointVelocity.hh>
 #include <ignition/gazebo/components/JointVelocityCmd.hh>
+#include <ignition/gazebo/components/LinearVelocityCmd.hh>
+#include <ignition/gazebo/components/AngularVelocityCmd.hh>
+#include <ignition/gazebo/components/PhysicsEnginePlugin.hh>
+#include <ignition/gazebo/components/Pose.hh>
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -29,14 +33,31 @@ class IGNITION_GAZEBO_VISIBLE DoorPlugin
   public ISystemPreUpdate
 {
 private:
+  struct DoorElement {
+    Entity link_entity;
+    Entity joint_entity;
+    ignition::math::Pose3d orig_position;
+    double orig_rotation;
+  };
+
   rclcpp::Node::SharedPtr _ros_node;
-  std::unordered_map<std::string, Entity> _joints;
+  std::unordered_map<std::string, Entity> _link_entities;
+  std::unordered_map<std::string, Entity> _joint_entities;
+  Entity _en;
+
+  std::unordered_map<Entity, ignition::math::Pose3d> orig_positions;
+  std::string _physics_plugin_name;
+  ignition::math::Pose3d orig_pos;
+  double orig_rot = 0.0;
+  bool pos_set = false;
+  int axis = 0;
+  double vel_cmd = 0.0;
 
   std::shared_ptr<DoorCommon> _door_common = nullptr;
 
   bool _initialized = false;
 
-  void create_entity_components(Entity entity, EntityComponentManager& ecm)
+  void create_joint_components(Entity entity, EntityComponentManager& ecm)
   {
     if (!ecm.EntityHasComponentType(entity,
       components::JointPosition().TypeId()))
@@ -47,6 +68,25 @@ private:
     if (!ecm.EntityHasComponentType(entity,
       components::JointVelocityCmd().TypeId()))
       ecm.CreateComponent(entity, components::JointVelocityCmd({0}));
+  }
+
+  void create_link_components(Entity entity, EntityComponentManager& ecm)
+  {
+    if (!ecm.EntityHasComponentType(entity,
+      components::LinearVelocityCmd().TypeId()))
+      ecm.CreateComponent(entity, components::LinearVelocityCmd());
+    if (!ecm.EntityHasComponentType(entity,
+      components::AngularVelocityCmd().TypeId()))
+      ecm.CreateComponent(entity, components::AngularVelocityCmd());
+    if (!ecm.EntityHasComponentType(entity,
+        components::Pose().TypeId()))
+      ecm.CreateComponent(entity, components::Pose());
+  }
+
+  bool is_tpe_plugin(const std::string& plugin_name)
+  {
+    static const std::string tpe_plugin = "ignition-physics-tpe-plugin";
+    return plugin_name == tpe_plugin;
   }
 
 public:
@@ -63,6 +103,7 @@ public:
     //_ros_node = gazebo_ros::Node::Get(sdf);
     // TODO get properties from sdf instead of hardcoded (will fail for multiple instantiations)
     // TODO proper rclcpp init (only once and pass args)
+    _en = entity;
     auto model = Model(entity);
     char const** argv = NULL;
     std::string name;
@@ -86,18 +127,29 @@ public:
     if (!_door_common)
       return;
 
-    for (const auto& joint_name : _door_common->joint_names())
+    for (const auto& door_elem : _door_common->_doors)
     {
-      const auto joint = model.JointByName(ecm, joint_name);
+      const auto link = model.LinkByName(ecm, door_elem.second.link_name);
+      if (link == kNullEntity)
+      {
+        RCLCPP_ERROR(_ros_node->get_logger(),
+          " -- Door model is missing the link [%s]",
+          door_elem.second.link_name.c_str());
+        return;
+      }
+      create_link_components(link, ecm);
+      _link_entities.insert({door_elem.second.joint_name, link});
+
+      const auto joint = model.JointByName(ecm, door_elem.second.joint_name);
       if (!joint)
       {
         RCLCPP_ERROR(_ros_node->get_logger(),
-          " -- Model is missing the joint [%s]",
-          joint_name.c_str());
+          " -- Door model is missing the joint [%s]",
+          door_elem.second.joint_name.c_str());
         return;
       }
-      create_entity_components(joint, ecm);
-      _joints.insert({joint_name, joint});
+      create_joint_components(joint, ecm);
+      _joint_entities.insert({door_elem.second.joint_name, joint});
     }
 
     _initialized = true;
@@ -114,36 +166,123 @@ public:
     if (!_initialized)
       return;
 
+    if(!pos_set){
+
+      orig_pos = ecm.Component<components::Pose>(_en)->Data();
+      orig_rot = ecm.Component<components::Pose>(_en)->Data().Yaw();
+
+      Entity parent = _en;
+      while(ecm.ParentEntity(parent)){
+        parent = ecm.ParentEntity(parent);
+      }
+      if (ecm.EntityHasComponentType(parent,
+          components::PhysicsEnginePlugin().TypeId())){
+            _physics_plugin_name = ecm.Component<components::PhysicsEnginePlugin>(parent)->Data();
+      }
+      pos_set = true;
+    }
+
     double t =
       (std::chrono::duration_cast<std::chrono::nanoseconds>(info.simTime).
       count()) * 1e-9;
 
     // Create DoorUpdateRequest
     std::vector<DoorCommon::DoorUpdateRequest> requests;
-    for (const auto& joint : _joints)
+    for (const auto& door : _door_common->_doors)
     {
+      Entity link = _link_entities[door.first];
       DoorCommon::DoorUpdateRequest request;
-      request.joint_name = joint.first;
-      request.position = ecm.Component<components::JointPosition>(
-        joint.second)->Data()[0];
-      request.velocity = ecm.Component<components::JointVelocity>(
-        joint.second)->Data()[0];
+      request.joint_name = door.first;
+
+      if(is_tpe_plugin(_physics_plugin_name)) // No joint features support, use velocity commands instead. May need axis too
+      {
+        const DoorCommon::DoorElement& door_elem = door.second;
+        constexpr double eps = 0.01;
+        if(door_elem.door_type == "SwingDoor" || door_elem.door_type == "DoubleSwingDoor")
+        {
+          // In the event that Yaw angle of the door moves past -Pi rads, it experiences a discontinuous jump from -Pi to Pi (likewise when the Yaw angle moves past Pi)
+          // We need to take this jump into account when calculating the relative orientation of the door w.r.t to its original orientation
+          if(door_elem.closed_position > door_elem.open_position)
+          {
+            // Yaw may go past -Pi rads when opening, and experience discontinuous jump to +Pi. For e.g. when original angle is -(7/8)Pi, opening the door by Pi/2 rads would
+            // push it past -Pi rads.
+            // If closed position (0 rads) is larger than open position, then the relative orientation should theoretically never exceed 0,
+            //which is how we identify when it has experienced a discontinuous jump
+            request.position = ecm.Component<components::Pose>(link)->Data().Yaw() - orig_rot > eps ?
+              -3.14 - fmod(ecm.Component<components::Pose>(link)->Data().Yaw() - orig_rot,3.14) : ecm.Component<components::Pose>(link)->Data().Yaw() - orig_rot;
+          }
+          else // Yaw may go past +180, and experience discontinuous jump to -180
+          {
+            request.position = ecm.Component<components::Pose>(link)->Data().Yaw() - orig_rot < -eps ?
+              3.14 + abs(-3.14 - (ecm.Component<components::Pose>(link)->Data().Yaw() - orig_rot)) : ecm.Component<components::Pose>(link)->Data().Yaw() - orig_rot;
+          }
+        }
+        else if(door_elem.door_type == "SlidingDoor" || door_elem.door_type == "DoubleSlidingDoor")
+        {
+            ignition::math::Pose3d curr_pos = ecm.Component<components::Pose>(link)->Data();
+            ignition::math::Vector3d displacement = curr_pos.CoordPositionSub(orig_pos);
+            //std::cout << "diff: " << displacement.Length() << std::endl;
+            request.position = displacement.Length();
+        }
+        else
+        {
+          continue;
+        }
+        //std::cout << "pos: " << request.position << std::endl;
+        //std::cout << "result vel: " << vel_cmd << std::endl;
+        request.velocity = vel_cmd;
+      }
+      else // Default Physics Engine with Joint Features support
+      {
+        Entity joint = _joint_entities[door.first];
+        request.position = ecm.Component<components::JointPosition>(
+          joint)->Data()[0];
+        request.velocity = ecm.Component<components::JointVelocity>(
+          joint)->Data()[0];
+      }
+
       requests.push_back(request);
     }
 
+    // Get and apply motions to the joints
     auto results = _door_common->update(t, requests);
-
-    // Apply motions to the joints
     for (const auto& result : results)
     {
-      const auto it = _joints.find(result.joint_name);
-      assert(it != _joints.end());
-      auto vel_cmd = ecm.Component<components::JointVelocityCmd>(
-        it->second);
-      vel_cmd->Data()[0] = result.velocity;
+      Entity link = _link_entities[result.joint_name];
+      const auto it = _door_common->_doors.find(result.joint_name);
+      assert(it != _door_common->_doors.end());
+
+      //to get door element section
+      if(is_tpe_plugin(_physics_plugin_name))
+      {
+        vel_cmd = result.velocity;
+        const DoorCommon::DoorElement& door_elem = it->second;
+        if(door_elem.door_type == "SwingDoor" || door_elem.door_type == "DoubleSwingDoor")
+        {
+          ecm.Component<components::LinearVelocityCmd>(link)->Data() = ignition::math::Vector3d(0,-0.5*vel_cmd,0);
+          ecm.Component<components::AngularVelocityCmd>(link)->Data() = ignition::math::Vector3d(0,0,vel_cmd);
+        }
+        else if(door_elem.door_type == "SlidingDoor")
+        {
+          ecm.Component<components::LinearVelocityCmd>(link)->Data() = ignition::math::Vector3d(vel_cmd,0,0);
+        }
+        else
+        {
+          continue;
+        }
+        //std::cout << "velocity: " << result.velocity << std::endl;
+        //std::cout << "Door Pose: " << ecm.Component<components::Pose>(_en)->Data() << std::endl;
+        //std::cout << "Link Pose: " << ecm.Component<components::Pose>(link)->Data() << std::endl;
+      }
+      else // Default Physics Engine with Joint Features support
+      {
+        Entity joint = _joint_entities[result.joint_name];
+        auto joint_vel_cmd = ecm.Component<components::JointVelocityCmd>(
+          joint);
+        joint_vel_cmd->Data()[0] = result.velocity;
+      }
     }
   }
-
 };
 
 IGNITION_ADD_PLUGIN(

--- a/building_sim_plugins/building_ignition_plugins/src/lift.cpp
+++ b/building_sim_plugins/building_ignition_plugins/src/lift.cpp
@@ -31,10 +31,6 @@ using namespace building_sim_common;
 
 namespace building_sim_ign {
 
-enum class PhysEnginePlugin {DEFAULT, TPE};
-std::unordered_map<std::string, PhysEnginePlugin> plugin_names {
-  {"ignition-physics-tpe-plugin", PhysEnginePlugin::TPE}};
-
 //==============================================================================
 
 class IGNITION_GAZEBO_VISIBLE LiftPlugin

--- a/building_sim_plugins/building_ignition_plugins/src/slotcar.cpp
+++ b/building_sim_plugins/building_ignition_plugins/src/slotcar.cpp
@@ -26,10 +26,6 @@ using namespace ignition::gazebo;
 
 using namespace building_sim_common;
 
-enum class PhysEnginePlugin {DEFAULT, TPE};
-std::unordered_map<std::string, PhysEnginePlugin> plugin_names {
-  {"ignition-physics-tpe-plugin", PhysEnginePlugin::TPE}};
-
 class IGNITION_GAZEBO_VISIBLE SlotcarPlugin
   : public System,
   public ISystemConfigure,

--- a/building_sim_plugins/building_plugins_common/include/building_sim_common/door_common.hpp
+++ b/building_sim_plugins/building_plugins_common/include/building_sim_common/door_common.hpp
@@ -74,7 +74,6 @@ public:
 
   struct DoorElement
   {
-    std::string type;
     std::string link_name;
     std::string joint_name;
     double length;
@@ -86,15 +85,13 @@ public:
     DoorElement() {}
 
     DoorElement(
-      const std::string& type,
       const std::string& link_name,
       const std::string& joint_name,
       const double length,
       const double lower_limit,
       const double upper_limit,
       const bool flip_direction = false)
-    : type(type),
-      link_name(link_name),
+    : link_name(link_name),
       joint_name(joint_name),
       length(length),
       current_position(0.0),
@@ -175,16 +172,13 @@ std::shared_ptr<DoorCommon> DoorCommon::make(
   auto door_element = sdf_clone;
   std::string left_door_joint_name;
   std::string right_door_joint_name;
-  std::string door_type;
 
   // Get the joint names and door type
   if (!get_element_required(sdf_clone, "door", door_element) ||
     !get_sdf_attribute_required<std::string>(
       door_element, "left_joint_name", left_door_joint_name) ||
     !get_sdf_attribute_required<std::string>(
-      door_element, "right_joint_name", right_door_joint_name) ||
-    !get_sdf_attribute_required<std::string>(
-      door_element, "type", door_type))
+      door_element, "right_joint_name", right_door_joint_name))
   {
     RCLCPP_ERROR(node->get_logger(),
       " -- Missing required parameters for [%s] plugin",
@@ -285,9 +279,9 @@ std::shared_ptr<DoorCommon> DoorCommon::make(
         DoorCommon::DoorElement door_element;
         if (joint_name == right_door_joint_name)
           door_element =
-            DoorCommon::DoorElement{door_type, link_name, joint_name, length, lower_limit, upper_limit, true};
+            DoorCommon::DoorElement{link_name, joint_name, length, lower_limit, upper_limit, true};
         else if (joint_name == left_door_joint_name)
-          door_element = DoorCommon::DoorElement{door_type, link_name, joint_name, length, lower_limit, upper_limit};
+          door_element = DoorCommon::DoorElement{link_name, joint_name, length, lower_limit, upper_limit};
         doors.insert({joint_name, door_element});
       }
     };

--- a/building_sim_plugins/building_plugins_common/include/building_sim_common/door_common.hpp
+++ b/building_sim_plugins/building_plugins_common/include/building_sim_common/door_common.hpp
@@ -235,16 +235,16 @@ std::shared_ptr<DoorCommon> DoorCommon::make(
         // Get name of the link associated with the joint
         std::string link_name;
         get_sdf_param_required<std::string>(
-              element, "child", link_name);
+          element, "child", link_name);
 
         // Find link and get its dimensions
         double length = 0.0;
         auto link = parent->GetElement("link");
         std::string link_search_name;
-        while(link && get_sdf_attribute_required<std::string>(
-          link, "name", link_search_name))
+        while (link && get_sdf_attribute_required<std::string>(
+            link, "name", link_search_name))
         {
-          if(link_search_name == link_name)
+          if (link_search_name == link_name)
           {
             auto visual = link->GetElement("visual");
             if (visual)
@@ -265,7 +265,7 @@ std::shared_ptr<DoorCommon> DoorCommon::make(
           {
             link = link->GetNextElement("link");
           }
-        };
+        }
 
         // Get joint parameters
         get_element_required(joint_sdf_clone, "axis", element);
@@ -279,9 +279,11 @@ std::shared_ptr<DoorCommon> DoorCommon::make(
         DoorCommon::DoorElement door_element;
         if (joint_name == right_door_joint_name)
           door_element =
-            DoorCommon::DoorElement{link_name, joint_name, length, lower_limit, upper_limit, true};
+            DoorCommon::DoorElement{link_name, joint_name, length, lower_limit,
+            upper_limit, true};
         else if (joint_name == left_door_joint_name)
-          door_element = DoorCommon::DoorElement{link_name, joint_name, length, lower_limit, upper_limit};
+          door_element = DoorCommon::DoorElement{link_name, joint_name, length,
+            lower_limit, upper_limit};
         doors.insert({joint_name, door_element});
       }
     };

--- a/building_sim_plugins/building_plugins_common/include/building_sim_common/door_common.hpp
+++ b/building_sim_plugins/building_plugins_common/include/building_sim_common/door_common.hpp
@@ -77,6 +77,7 @@ public:
     std::string door_type;
     std::string link_name;
     std::string joint_name;
+    double length;
     double closed_position;
     double open_position;
     double current_position;
@@ -88,12 +89,14 @@ public:
       const std::string& door_type,
       const std::string& link_name,
       const std::string& joint_name,
+      const double length,
       const double lower_limit,
       const double upper_limit,
       const bool flip_direction = false)
     : door_type(door_type),
       link_name(link_name),
       joint_name(joint_name),
+      length(length),
       current_position(0.0),
       current_velocity(0.0)
     {
@@ -207,38 +210,6 @@ std::shared_ptr<DoorCommon> DoorCommon::make(
 
   Doors doors;
 
-  auto extract_door = [&](SdfPtrT& joint_sdf)
-    {
-      auto joint_sdf_clone = joint_sdf->Clone();
-      std::string joint_name;
-      get_sdf_attribute_required<std::string>(
-        joint_sdf_clone, "name", joint_name);
-      const auto it = joint_names.find(joint_name);
-      if (it != joint_names.end())
-      {
-        auto element = joint_sdf_clone;
-
-        std::string link_name;
-        get_sdf_param_required<std::string>(
-              element, "child", link_name);
-
-        get_element_required(joint_sdf_clone, "axis", element);
-        get_element_required(element, "limit", element);
-        double lower_limit = -1.57;
-        double upper_limit = 0.0;
-        get_sdf_param_if_available<double>(element, "lower", lower_limit);
-        get_sdf_param_if_available<double>(element, "upper", upper_limit);
-
-        DoorCommon::DoorElement door_element;
-        if (joint_name == right_door_joint_name)
-          door_element =
-            DoorCommon::DoorElement{door_type, link_name, joint_name, lower_limit, upper_limit, true};
-        else if (joint_name == left_door_joint_name)
-          door_element = DoorCommon::DoorElement{door_type, link_name, joint_name, lower_limit, upper_limit};
-        doors.insert({joint_name, door_element});
-      }
-    };
-
   // Get the joint limits from parent sdf
   auto parent = sdf->GetParent();
   if (!parent)
@@ -256,7 +227,71 @@ std::shared_ptr<DoorCommon> DoorCommon::make(
     return nullptr;
   }
 
-  extract_door(joint_element);
+  auto extract_door = [&](SdfPtrT& joint_sdf)
+    {
+      auto joint_sdf_clone = joint_sdf->Clone();
+      std::string joint_name;
+      get_sdf_attribute_required<std::string>(
+        joint_sdf_clone, "name", joint_name);
+      const auto it = joint_names.find(joint_name);
+      if (it != joint_names.end())
+      {
+        auto element = joint_sdf_clone;
+
+        // Get name of the link associated with the joint
+        std::string link_name;
+        get_sdf_param_required<std::string>(
+              element, "child", link_name);
+
+        // Get the link's dimensions
+        double length = 0.0;
+        auto link = parent->GetElement("link");
+        std::string link_search_name;
+        while(link && get_sdf_attribute_required<std::string>(
+          link, "name", link_search_name))
+        {
+          if(link_search_name == link_name)
+          {
+            auto visual = link->GetElement("visual");
+            if (visual)
+            {
+              auto geometry = visual->GetElement("geometry");
+              if (geometry)
+              {
+                auto box = geometry->GetElement("box");
+                if (box)
+                {
+                  get_sdf_param_required<double>(box, "size", length);
+                }
+              }
+            }
+            break;
+          }
+          else
+          {
+            link = link->GetNextElement("link");
+          }
+        };
+
+        // Get joint parameters
+        get_element_required(joint_sdf_clone, "axis", element);
+        get_element_required(element, "limit", element);
+        double lower_limit = -1.57;
+        double upper_limit = 0.0;
+        get_sdf_param_if_available<double>(element, "lower", lower_limit);
+        get_sdf_param_if_available<double>(element, "upper", upper_limit);
+
+        // Create DoorElement corresponding to link+joint pair
+        DoorCommon::DoorElement door_element;
+        if (joint_name == right_door_joint_name)
+          door_element =
+            DoorCommon::DoorElement{door_type, link_name, joint_name, length, lower_limit, upper_limit, true};
+        else if (joint_name == left_door_joint_name)
+          door_element = DoorCommon::DoorElement{door_type, link_name, joint_name, length, lower_limit, upper_limit};
+        doors.insert({joint_name, door_element});
+      }
+    };
+
   // Find next joint element if present
   while (joint_element)
   {

--- a/building_sim_plugins/building_plugins_common/include/building_sim_common/door_common.hpp
+++ b/building_sim_plugins/building_plugins_common/include/building_sim_common/door_common.hpp
@@ -74,7 +74,7 @@ public:
 
   struct DoorElement
   {
-    std::string door_type;
+    std::string type;
     std::string link_name;
     std::string joint_name;
     double length;
@@ -86,14 +86,14 @@ public:
     DoorElement() {}
 
     DoorElement(
-      const std::string& door_type,
+      const std::string& type,
       const std::string& link_name,
       const std::string& joint_name,
       const double length,
       const double lower_limit,
       const double upper_limit,
       const bool flip_direction = false)
-    : door_type(door_type),
+    : type(type),
       link_name(link_name),
       joint_name(joint_name),
       length(length),
@@ -243,7 +243,7 @@ std::shared_ptr<DoorCommon> DoorCommon::make(
         get_sdf_param_required<std::string>(
               element, "child", link_name);
 
-        // Get the link's dimensions
+        // Find link and get its dimensions
         double length = 0.0;
         auto link = parent->GetElement("link");
         std::string link_search_name;

--- a/building_sim_plugins/building_plugins_common/include/building_sim_common/utils.hpp
+++ b/building_sim_plugins/building_plugins_common/include/building_sim_common/utils.hpp
@@ -3,8 +3,14 @@
 
 #include <cmath>
 #include <iostream>
+#include <string>
+#include <unordered_map>
 
 namespace building_sim_common {
+
+enum class PhysEnginePlugin {DEFAULT, TPE};
+std::unordered_map<std::string, PhysEnginePlugin> plugin_names {
+  {"ignition-physics-tpe-plugin", PhysEnginePlugin::TPE}};
 
 // TODO(MXG): Refactor the use of this function to replace it with
 // compute_desired_rate_of_change()


### PR DESCRIPTION
Uses link-level `LinearVelocityCmd`s and `AngularVelocityCmd`s to mimic motion of the joints. The code for TPE is slightly more complicated because we need to take care of things like reference frames, command directions and discontinuities in rotation angle, which were previously automatically taken care of by the joints.

Depends on ignitionrobotics/ign-gazebo#427, so this may need to be updated depending on what gets changed in that pull request.