### PR TITLE
Switch to PeriodicChange for ignition crowd simulation plugins

### DIFF
--- a/building_sim_plugins/building_ignition_plugins/src/crowd_simulator.cpp
+++ b/building_sim_plugins/building_ignition_plugins/src/crowd_simulator.cpp
@@ -438,10 +438,9 @@ void CrowdSimulatorPlugin::_update_internal_object(
       break;
   }
 
-  //if (obj_ptr->current_state != next_state)
-    ecm.SetChanged(entity,
-      ignition::gazebo::components::AnimationName::typeId,
-      ignition::gazebo::ComponentState::PeriodicChange);
+  ecm.SetChanged(entity,
+    ignition::gazebo::components::AnimationName::typeId,
+    ignition::gazebo::ComponentState::PeriodicChange);
   obj_ptr->current_state = next_state;
 
   // set trajectory

--- a/building_sim_plugins/building_ignition_plugins/src/crowd_simulator.cpp
+++ b/building_sim_plugins/building_ignition_plugins/src/crowd_simulator.cpp
@@ -395,7 +395,7 @@ void CrowdSimulatorPlugin::_update_internal_object(
   }
   auto anim_time_comp =
     ecm.Component<ignition::gazebo::components::AnimationTime>(entity);
-  if (nullptr == anim_name_comp)
+  if (nullptr == anim_time_comp)
   {
     RCLCPP_ERROR(_crowd_sim_interface->logger(),
       "Model [" + obj_ptr->model_name + "] has no AnimationTime component.");
@@ -438,20 +438,20 @@ void CrowdSimulatorPlugin::_update_internal_object(
       break;
   }
 
-  if (obj_ptr->current_state != next_state)
+  //if (obj_ptr->current_state != next_state)
     ecm.SetChanged(entity,
       ignition::gazebo::components::AnimationName::typeId,
-      ignition::gazebo::ComponentState::OneTimeChange);
+      ignition::gazebo::ComponentState::PeriodicChange);
   obj_ptr->current_state = next_state;
 
   // set trajectory
   traj_pose_comp->Data() = agent_pose;
   ecm.SetChanged(entity,
     ignition::gazebo::components::TrajectoryPose::typeId,
-    ignition::gazebo::ComponentState::OneTimeChange);
+    ignition::gazebo::ComponentState::PeriodicChange);
   ecm.SetChanged(entity,
     ignition::gazebo::components::AnimationTime::typeId,
-    ignition::gazebo::ComponentState::OneTimeChange);
+    ignition::gazebo::ComponentState::PeriodicChange);
 }
 
 } //namespace crowd_simulation_ign


### PR DESCRIPTION
The use of `OneTimeChange` for components in ignition causes the scene broadcaster to serialize and publish the whole state, incurring in a major performance loss when using the ignition crowd simulation plugin, as documented in [ign-gazebo](https://github.com/ignitionrobotics/ign-gazebo/pull/544).

This PR changes the components state to `PeriodicChange`, to be merged after the matching [ign-gazebo PR](https://github.com/ignitionrobotics/ign-gazebo/pull/544) (or to be updated if the issue is fixed in a different way).