### PR TITLE
Fix thumbnail rendering crash

### DIFF
--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -1599,7 +1599,6 @@ void Editor::property_editor_cell_changed(int row, int column)
 
 bool Editor::create_scene()
 {
-  printf("Editor::create_scene()\n");
   scene->clear();  // destroys the mouse_motion_* items if they are there
   project.clear_scene();  // forget all pointers to the graphics items
   mouse_motion_line = nullptr;

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -595,9 +595,11 @@ void Editor::load_model_names()
 
   const double model_meters_per_pixel = y["meters_per_pixel"].as<double>();
   const YAML::Node ym = y["models"];
+  editor_models.reserve(y["models"].size());
   for (YAML::const_iterator it = ym.begin(); it != ym.end(); ++it)
-    editor_models.push_back(
-      EditorModel(it->as<std::string>(), model_meters_per_pixel));
+    editor_models.emplace_back(
+      it->as<std::string>(),
+      model_meters_per_pixel);
 }
 
 QToolButton* Editor::create_tool_button(
@@ -1597,10 +1599,9 @@ void Editor::property_editor_cell_changed(int row, int column)
 
 bool Editor::create_scene()
 {
+  printf("Editor::create_scene()\n");
   scene->clear();  // destroys the mouse_motion_* items if they are there
-#ifdef HAS_IGNITION_PLUGIN
   project.clear_scene();  // forget all pointers to the graphics items
-#endif
   mouse_motion_line = nullptr;
   mouse_motion_model = nullptr;
   mouse_motion_ellipse = nullptr;

--- a/traffic_editor/gui/project.cpp
+++ b/traffic_editor/gui/project.cpp
@@ -61,7 +61,7 @@ bool Project::load_yaml_file(const std::string& _filename)
   // we load are in different directories (!)
 
   QString dir(QFileInfo(QString::fromStdString(filename)).absolutePath());
-  printf("changing directory to [%s]", qUtf8Printable(dir));
+  printf("changing directory to [%s]\n", qUtf8Printable(dir));
   if (!QDir::setCurrent(dir))
   {
     printf("couldn't change directory\n");


### PR DESCRIPTION
There was an `ifdef` block inserted during one of the code cleanups that was incorrect, and will cause rendering crashes during the second redraw of model thumbnails on systems where `libignition-plugin` is not detected. This is due to the way that the code is keeping raw pointers to Qt-owned graphics objects that become invalid when the scene is cleared. Removing this `ifdef` check ensures that the pointers to the model thumbnail `QPixmapItem` objects are always discarded when the scene is cleared.