### PR TITLE
place orientation icon at correct Z stack so it's visible again

### DIFF
--- a/traffic_editor/gui/building_level.cpp
+++ b/traffic_editor/gui/building_level.cpp
@@ -611,14 +611,16 @@ void BuildingLevel::draw_lane(
       const double hix = mx + 1.0 * cos(yaw) / drawing_meters_per_pixel;
       const double hiy = my + 1.0 * sin(yaw) / drawing_meters_per_pixel;
       pp.lineTo(QPointF(hix, hiy));
-      scene->addPath(pp, orientation_pen);
+      QGraphicsPathItem *pi = scene->addPath(pp, orientation_pen);
+      pi->setZValue(edge.get_graph_idx() + 1.1);
     }
     else if (orientation_it->second.value_string == "backward")
     {
       const double hix = mx - 1.0 * cos(yaw) / drawing_meters_per_pixel;
       const double hiy = my - 1.0 * sin(yaw) / drawing_meters_per_pixel;
       pp.lineTo(QPointF(hix, hiy));
-      scene->addPath(pp, orientation_pen);
+      QGraphicsPathItem *pi = scene->addPath(pp, orientation_pen);
+      pi->setZValue(edge.get_graph_idx() + 1.1);
     }
   }
 }

--- a/traffic_editor/gui/building_level.cpp
+++ b/traffic_editor/gui/building_level.cpp
@@ -611,7 +611,7 @@ void BuildingLevel::draw_lane(
       const double hix = mx + 1.0 * cos(yaw) / drawing_meters_per_pixel;
       const double hiy = my + 1.0 * sin(yaw) / drawing_meters_per_pixel;
       pp.lineTo(QPointF(hix, hiy));
-      QGraphicsPathItem *pi = scene->addPath(pp, orientation_pen);
+      QGraphicsPathItem* pi = scene->addPath(pp, orientation_pen);
       pi->setZValue(edge.get_graph_idx() + 1.1);
     }
     else if (orientation_it->second.value_string == "backward")
@@ -619,7 +619,7 @@ void BuildingLevel::draw_lane(
       const double hix = mx - 1.0 * cos(yaw) / drawing_meters_per_pixel;
       const double hiy = my - 1.0 * sin(yaw) / drawing_meters_per_pixel;
       pp.lineTo(QPointF(hix, hiy));
-      QGraphicsPathItem *pi = scene->addPath(pp, orientation_pen);
+      QGraphicsPathItem* pi = scene->addPath(pp, orientation_pen);
       pi->setZValue(edge.get_graph_idx() + 1.1);
     }
   }


### PR DESCRIPTION
When we started to render using proper Z stacks, unfortunately the orientation icons were not assigned a Z height, so they were below everything. Fixed now.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>