### PR TITLE
building_map_tools feature: building_map_combiner

### DIFF
--- a/building_map_tools/building_map/building.py
+++ b/building_map_tools/building_map/building.py
@@ -240,14 +240,14 @@ class Building:
     def add_lanes_from(self, other_building):
         # go through each level and try to add lanes from the other building
         print(f'add_lanes_from()')
-        print(f'this building\'s levels: {list(self.levels.keys())}')
-        print(f'other building\'s levels: {list(other_building.levels.keys())}')
+        print(f'our levels: {list(self.levels.keys())}')
+        print(f'other levels: {list(other_building.levels.keys())}')
         for level_name, level in self.levels.items():
             if level_name in other_building.levels.keys():
                 print(f'level {level_name} exists in both buildings')
                 level.add_lanes_from(other_building.levels[level_name])
             else:
-                print(f'WARNING: level {level_name} does not exist in both buildings')
+                print(f'WARNING: {level_name} does not exist in both')
 
     def write_yaml_file(self, filename):
         with open(filename, 'w') as f:

--- a/building_map_tools/building_map/building.py
+++ b/building_map_tools/building_map/building.py
@@ -1,6 +1,7 @@
 import math
 import numpy as np
 import os
+import yaml
 from xml.etree.ElementTree import Element, SubElement, parse
 from ament_index_python.packages import get_package_share_directory
 
@@ -306,3 +307,22 @@ class Building:
         # todo: something smarter in the future. For now just the center
         # of the first level
         return self.levels[list(self.levels.keys())[0]].center()
+
+    def add_lanes_from(self, other_building):
+        pass
+
+    def write_yaml_file(self, filename):
+        with open(filename, 'w') as f:
+            d = {}
+            d['name'] = self.name
+            d['reference_level_name'] = self.reference_level_name
+
+            d['levels'] = {}
+            for level_name, level_data in self.levels.items():
+                d['levels'][level_name] = level_data.to_yaml()
+
+            d['lifts'] = {}
+            for lift_name, lift in self.lifts.items():
+                d['lifts'][lift_name] = lift.to_yaml()
+
+            yaml.dump(d, f)

--- a/building_map_tools/building_map/building.py
+++ b/building_map_tools/building_map/building.py
@@ -309,7 +309,16 @@ class Building:
         return self.levels[list(self.levels.keys())[0]].center()
 
     def add_lanes_from(self, other_building):
-        pass
+        # go through each level and try to add lanes from the other building
+        print(f'add_lanes_from()')
+        print(f'this building\'s levels: {list(self.levels.keys())}')
+        print(f'other building\'s levels: {list(other_building.levels.keys())}')
+        for level_name, level in self.levels.items():
+            if level_name in other_building.levels.keys():
+                print(f'level {level_name} exists in both buildings')
+                level.add_lanes_from(other_building.levels[level_name])
+            else:
+                print(f'WARNING: level {level_name} does not exist in both buildings')
 
     def write_yaml_file(self, filename):
         with open(filename, 'w') as f:

--- a/building_map_tools/building_map/building.py
+++ b/building_map_tools/building_map/building.py
@@ -90,80 +90,9 @@ class Building:
                 if ref_fiducial.name == fiducial.name:
                     fiducials.append((ref_fiducial, fiducial))
         print(f'  {len(fiducials)} common fiducials:')
-        for f_pair in fiducials:
-            f0 = f_pair[0]
-            f1 = f_pair[1]
-            print(
-                f'    ({float(f0.x):.5}, {float(f0.y):.5})'
-                f' -> ({float(f1.x):.5}, {float(f1.y):.5})'
-                f'   {f0.name}')
-
-        # calculate the bearings and distances between each fiducial pair
-        distances = []
-        bearings = []
-        for f0_idx in range(0, len(fiducials)):
-            for f1_idx in range(f0_idx + 1, len(fiducials)):
-                f0_pair = fiducials[f0_idx]
-                f1_pair = fiducials[f1_idx]
-                print(f'    calc dist {f0_pair[0].name} <=> {f1_pair[0].name}')
-
-                ref_bearing = f0_pair[0].bearing(f1_pair[0])
-                target_bearing = f0_pair[1].bearing(f1_pair[1])
-                bearings.append((ref_bearing, target_bearing))
-
-                ref_dist = f0_pair[0].distance(f1_pair[0])
-                target_dist = f0_pair[1].distance(f1_pair[1])
-                distances.append((ref_dist, target_dist))
-
-        print("Bearings:")
-        print(bearings)
-        if len(bearings) == 0:
-            return
-
-        # compute the circular mean of the difference between the bearings
-        bearing_sum = [0.0, 0.0]
-        for bearing_pair in bearings:
-            d_theta = bearing_pair[1] - bearing_pair[0]
-            bearing_sum[0] += math.sin(d_theta)
-            bearing_sum[1] += math.cos(d_theta)
-            print(f'  {d_theta}')
-        mean_bearing_difference = -math.atan2(bearing_sum[0], bearing_sum[1])
-        print(f'  Circular mean: {mean_bearing_difference}')
-        level.transform.set_rotation(mean_bearing_difference)
-
-        print("Distances:")
-        print(distances)
-
-        mean_rel_scale = 0.0
-        for distance in distances:
-            mean_rel_scale += distance[1] / distance[0]
-        mean_rel_scale /= float(len(distances))
-        print(f'mean relative scale: {mean_rel_scale}')
-        ref_scale = self.ref_level.transform.scale
-        level.transform.set_scale(ref_scale / mean_rel_scale)
-
-        mean_translation = [0.0, 0.0]
-        cr = math.cos(mean_bearing_difference)
-        sr = math.sin(mean_bearing_difference)
-        for f_pair in fiducials:
-            rot_mat = np.array([[cr, -sr], [sr, cr]])
-            f1x = f_pair[1].x / mean_rel_scale
-            f1y = f_pair[1].y / mean_rel_scale
-            rot_f_pair1 = rot_mat @ np.array([[f1x], [f1y]])
-            rot_f1x = np.asscalar(rot_f_pair1[0])
-            rot_f1y = np.asscalar(rot_f_pair1[1])
-
-            mean_translation[0] += rot_f1x - f_pair[0].x
-            mean_translation[1] += rot_f1y - f_pair[0].y
-
-        if len(fiducials):
-            mean_translation[0] *= -ref_scale / float(len(fiducials))
-            mean_translation[1] *= -ref_scale / float(len(fiducials))
-        print(
-            f'translation: '
-            f'({mean_translation[0]:.5}, '
-            f'{mean_translation[1]:.5})')
-        level.transform.set_translation(*mean_translation)
+        level.transform.set_from_fiducials(
+            fiducials,
+            self.ref_level.transform.scale)
 
     def generate_nav_graphs(self):
         """ Returns a dict of all non-empty nav graphs """

--- a/building_map_tools/building_map/edge.py
+++ b/building_map_tools/building_map/edge.py
@@ -11,6 +11,12 @@ class Edge:
             for param_name, param_yaml in yaml_node[2].items():
                 self.params[param_name] = ParamValue(param_yaml)
 
+    def to_yaml(self):
+        y = [self.start_idx, self.end_idx, {}]
+        for param_name, param_value in self.params.items():
+            y[2][param_name] = param_value.to_yaml()
+        return y
+
     def calc_statistics(self, vertices):
         self.x1 = vertices[self.start_idx].x
         self.y1 = vertices[self.start_idx].y

--- a/building_map_tools/building_map/fiducial.py
+++ b/building_map_tools/building_map/fiducial.py
@@ -8,7 +8,7 @@ class Fiducial:
         self.name = yaml_node[2]
 
     def to_yaml(self):
-        return [self.x, self.y, self.name]
+        return [self.x, -self.y, self.name]
 
     def distance(self, f):
         """ Calculate distance to another fiducial """

--- a/building_map_tools/building_map/fiducial.py
+++ b/building_map_tools/building_map/fiducial.py
@@ -7,6 +7,9 @@ class Fiducial:
         self.y = -yaml_node[1]
         self.name = yaml_node[2]
 
+    def to_yaml(self):
+        return [self.x, self.y, self.name]
+
     def distance(self, f):
         """ Calculate distance to another fiducial """
         dx = f.x - self.x

--- a/building_map_tools/building_map/floor.py
+++ b/building_map_tools/building_map/floor.py
@@ -30,6 +30,14 @@ class Floor:
             for param_name, param_yaml in yaml_node['parameters'].items():
                 self.params[param_name] = ParamValue(param_yaml)
 
+    def to_yaml(self):
+        y = {}
+        y['vertices'] = self.vertex_indices
+        y['parameters'] = {}
+        for param_name, param_value in self.params.items():
+            y['parameters'][param_name] = param_value.to_yaml()
+        return y
+
     def __str__(self):
         return f'floor ({len(self.vertices)} vertices)'
 

--- a/building_map_tools/building_map/hole.py
+++ b/building_map_tools/building_map/hole.py
@@ -18,6 +18,14 @@ class Hole:
             for param_name, param_yaml in yaml_node['parameters'].items():
                 self.params[param_name] = ParamValue(param_yaml)
 
+    def to_yaml(self):
+        y = {}
+        y['vertices'] = self.vertex_indices
+        y['parameters'] = {}
+        for param_name, param_value in self.params.items():
+            y['parameters'][param_name] = param_value.to_yaml()
+        return y
+
     def __str__(self):
         return f'hole ({len(self.vertex_indices)} vertices)'
 

--- a/building_map_tools/building_map/level.py
+++ b/building_map_tools/building_map/level.py
@@ -460,3 +460,14 @@ class Level:
             return (0, 0)
         bounds = self.floors[0].polygon.bounds
         return ((bounds[0] + bounds[2]) / 2.0, (bounds[1] + bounds[3]) / 2.0)
+
+    def add_lanes_from(self, other):
+        print(f'add_lanes_from()')
+        print(f'  this level has {len(self.vertices)} vertices')
+        print(f'  other level has {len(other.vertices)} vertices')
+
+        # TODO: use fiducials to calculate transform between these spaces
+        self.vertices.extend(other.vertices)
+
+        for lane in other.lanes:
+            print(f'  other lane: {lane.start_idx} -> {lane.end_idx}')

--- a/building_map_tools/building_map/level.py
+++ b/building_map_tools/building_map/level.py
@@ -91,6 +91,24 @@ class Level:
             for hole_yaml in yaml_node['holes']:
                 self.holes.append(Hole(hole_yaml))
 
+    def to_yaml(self):
+        y = {}
+        if self.drawing_name:
+            y['drawing'] = {}
+            y['drawing']['filename'] = self.drawing_name
+        y['elevation'] = self.elevation
+
+        y['fiducials'] = [f.to_yaml() for f in self.fiducials]
+        y['vertices'] = [v.to_yaml() for v in self.vertices]
+        y['measurements'] = [e.to_yaml() for e in self.meas]
+        y['lanes'] = [e.to_yaml() for e in self.lanes]
+        y['walls'] = [e.to_yaml() for e in self.walls]
+        y['doors'] = [e.to_yaml() for e in self.doors]
+        y['models'] = [m.to_yaml() for m in self.models]
+        y['floors'] = [f.to_yaml() for f in self.floors]
+        y['holes'] = [h.to_yaml() for h in self.holes]
+        return y
+
     def transform_all_vertices(self):
         self.transformed_vertices = []
 

--- a/building_map_tools/building_map/lift.py
+++ b/building_map_tools/building_map/lift.py
@@ -322,7 +322,6 @@ class Lift:
             y['doors'][door.name] = door.to_yaml()
         return y
 
-
     def parse_lift_doors(self, yaml_node):
         doors = []
         for lift_door_name, lift_door_yaml in yaml_node.items():

--- a/building_map_tools/building_map/model.py
+++ b/building_map_tools/building_map/model.py
@@ -30,6 +30,17 @@ class Model:
 
         self.yaw = yaml_node['yaw']
 
+    def to_yaml(self):
+        y = {}
+        y['x'] = self.x
+        y['y'] = -self.y  # invert it back for the file format...
+        y['z'] = self.z
+        y['model_name'] = self.model_name
+        y['name'] = self.name
+        y['yaw'] = self.yaw
+        y['static'] = self.static
+        return y
+
     def generate(self, world_ele, transform, elevation):
         include_ele = SubElement(world_ele, 'include')
         name_ele = SubElement(include_ele, 'name')

--- a/building_map_tools/building_map/param_value.py
+++ b/building_map_tools/building_map/param_value.py
@@ -8,3 +8,6 @@ class ParamValue:
     def __init__(self, yaml_value):
         self.type = yaml_value[0]
         self.value = yaml_value[1]
+
+    def to_yaml(self):
+        return [self.type, self.value]

--- a/building_map_tools/building_map/transform.py
+++ b/building_map_tools/building_map/transform.py
@@ -28,3 +28,80 @@ class Transform:
         vec = np.array([[p[0]], [p[1]]])
         transformed = (self.rot_mat @ vec) * self.scale + self.t_vec
         return (np.asscalar(transformed[0]), np.asscalar(transformed[1]))
+
+    def set_from_fiducials(self, fiducial_pairs, ref_scale):
+        print(f'Transform.set_from_fiducials()')
+        print(f'  {len(fiducial_pairs)} fiducial pairs:')
+        for f_pair in fiducial_pairs:
+            f0 = f_pair[0]
+            f1 = f_pair[1]
+            print(
+                f'    ({float(f0.x):.5}, {float(f0.y):.5})'
+                f' -> ({float(f1.x):.5}, {float(f1.y):.5})'
+                f'   {f0.name}')
+
+        # calculate the bearings and distances between each fiducial pair
+        distances = []
+        bearings = []
+        for f0_idx in range(0, len(fiducial_pairs)):
+            for f1_idx in range(f0_idx + 1, len(fiducial_pairs)):
+                f0_pair = fiducial_pairs[f0_idx]
+                f1_pair = fiducial_pairs[f1_idx]
+                print(f'    calc dist {f0_pair[0].name} <=> {f1_pair[0].name}')
+
+                ref_bearing = f0_pair[0].bearing(f1_pair[0])
+                target_bearing = f0_pair[1].bearing(f1_pair[1])
+                bearings.append((ref_bearing, target_bearing))
+
+                ref_dist = f0_pair[0].distance(f1_pair[0])
+                target_dist = f0_pair[1].distance(f1_pair[1])
+                distances.append((ref_dist, target_dist))
+
+        print("Bearings:")
+        print(bearings)
+        if len(bearings) == 0:
+            return
+
+        # compute the circular mean of the difference between the bearings
+        bearing_sum = [0.0, 0.0]
+        for bearing_pair in bearings:
+            d_theta = bearing_pair[1] - bearing_pair[0]
+            bearing_sum[0] += math.sin(d_theta)
+            bearing_sum[1] += math.cos(d_theta)
+            print(f'  {d_theta}')
+        mean_bearing_difference = -math.atan2(bearing_sum[0], bearing_sum[1])
+        print(f'  Circular mean: {mean_bearing_difference}')
+        self.set_rotation(mean_bearing_difference)
+
+        print("Distances:")
+        print(distances)
+
+        mean_rel_scale = 0.0
+        for distance in distances:
+            mean_rel_scale += distance[1] / distance[0]
+        mean_rel_scale /= float(len(distances))
+        print(f'mean relative scale: {mean_rel_scale}')
+        self.set_scale(ref_scale / mean_rel_scale)
+
+        mean_translation = [0.0, 0.0]
+        cr = math.cos(mean_bearing_difference)
+        sr = math.sin(mean_bearing_difference)
+        for f_pair in fiducial_pairs:
+            rot_mat = np.array([[cr, -sr], [sr, cr]])
+            f1x = f_pair[1].x / mean_rel_scale
+            f1y = f_pair[1].y / mean_rel_scale
+            rot_f_pair1 = rot_mat @ np.array([[f1x], [f1y]])
+            rot_f1x = np.asscalar(rot_f_pair1[0])
+            rot_f1y = np.asscalar(rot_f_pair1[1])
+
+            mean_translation[0] += rot_f1x - f_pair[0].x
+            mean_translation[1] += rot_f1y - f_pair[0].y
+
+        if len(fiducial_pairs):
+            mean_translation[0] *= -ref_scale / float(len(fiducial_pairs))
+            mean_translation[1] *= -ref_scale / float(len(fiducial_pairs))
+        print(
+            f'translation: '
+            f'({mean_translation[0]:.5}, '
+            f'{mean_translation[1]:.5})')
+        self.set_translation(*mean_translation)

--- a/building_map_tools/building_map/vertex.py
+++ b/building_map_tools/building_map/vertex.py
@@ -17,7 +17,7 @@ class Vertex:
         return (self.x, self.y)
 
     def to_yaml(self):
-        y = [self.x, self.y, self.z, self.name, {}]
+        y = [self.x, -self.y, self.z, self.name, {}]
         for param_name, param_value in self.params.items():
             y[4][param_name] = param_value.to_yaml()
         return y

--- a/building_map_tools/building_map/vertex.py
+++ b/building_map_tools/building_map/vertex.py
@@ -15,3 +15,9 @@ class Vertex:
 
     def xy(self):
         return (self.x, self.y)
+
+    def to_yaml(self):
+        y = [self.x, self.y, self.z, self.name, {}]
+        for param_name, param_value in self.params.items():
+            y[4][param_name] = param_value.to_yaml()
+        return y

--- a/building_map_tools/building_map_combiner/building_map_combiner.py
+++ b/building_map_tools/building_map_combiner/building_map_combiner.py
@@ -8,16 +8,16 @@ from building_map.building import Building
 
 def main():
     parser = argparse.ArgumentParser(
-        prog="building_map_combiner",
-        description="Combine two .building.yaml files"
+        prog='building_map_combiner',
+        description='Combine two .building.yaml files'
     )
 
-    parser.add_argument("PRIMARY_INPUT", type=str,
-                        help="Primary building.yaml file")
-    parser.add_argument("SECONDARY_INPUT", type=str,
-                        help="Secondary building.yaml file")
-    parser.add_argument("OUTPUT", type=str,
-                        help="Output file will be PRIMARY + lanes(SECONDARY)")
+    parser.add_argument('PRIMARY_INPUT', type=str,
+                        help='Primary building.yaml file')
+    parser.add_argument('SECONDARY_INPUT', type=str,
+                        help='Secondary building.yaml file')
+    parser.add_argument('OUTPUT', type=str,
+                        help='Output file will be PRIMARY + lanes(SECONDARY)')
 
     args = parser.parse_args()
 
@@ -39,5 +39,5 @@ def main():
     primary.write_yaml_file(args.OUTPUT)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/building_map_tools/building_map_combiner/building_map_combiner.py
+++ b/building_map_tools/building_map_combiner/building_map_combiner.py
@@ -17,7 +17,7 @@ def main():
     parser.add_argument("SECONDARY_INPUT", type=str,
                         help="Secondary building.yaml file")
     parser.add_argument("OUTPUT", type=str,
-                        help="Output filename, will be PRIMARY + lanes(SECONDARY)")
+                        help="Output file will be PRIMARY + lanes(SECONDARY)")
 
     args = parser.parse_args()
 

--- a/building_map_tools/building_map_combiner/building_map_combiner.py
+++ b/building_map_tools/building_map_combiner/building_map_combiner.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import yaml
+
+from building_map.building import Building
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="building_map_combiner",
+        description="Combine two .building.yaml files"
+    )
+
+    parser.add_argument("PRIMARY_INPUT", type=str,
+                        help="Primary building.yaml file")
+    parser.add_argument("SECONDARY_INPUT", type=str,
+                        help="Secondary building.yaml file")
+    parser.add_argument("OUTPUT", type=str,
+                        help="Output filename, will be PRIMARY + lanes(SECONDARY)")
+
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.PRIMARY_INPUT):
+        raise FileNotFoundError(f'input file {args.PRIMARY_INPUT} not found')
+    if not os.path.isfile(args.SECONDARY_INPUT):
+        raise FileNotFoundError(f'input file {args.SECONDARY_INPUT} not found')
+
+    with open(args.PRIMARY_INPUT, 'r') as f:
+        y = yaml.safe_load(f)
+        primary = Building(y)
+
+    with open(args.SECONDARY_INPUT, 'r') as f:
+        y = yaml.safe_load(f)
+        secondary = Building(y)
+
+    print(f'parsed primary and secondary inputs')
+    primary.add_lanes_from(secondary)
+    primary.write_yaml_file(args.OUTPUT)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR introduces a new Python program, `building_map_combiner` and implements its functionality in the `building_map` Python package. It allows you to add vertices and traffic lanes from one map into another map. As the vertices are being added, they will be transformed into the same coordinate space using fiducials, provided there exist at least 3 equally-named fiducials in each map. This was implemented primarily by refactoring the existing fiducial-alignment code used for multi-floor world generation into a form that could be used for multi-map alignment.

In order to implement this feature, it was also necessary to add map-writing `to_yaml()` functions throughout the `building_map` Python package. It would be nicer if the YAML flow/block style toggling was happening the same way in this Python writing implementation as it currently does in C++, but I'll add that in a separate PR later.