### PR TITLE
change vertex shape for parking/holding points

### DIFF
--- a/traffic_editor/gui/building_level.cpp
+++ b/traffic_editor/gui/building_level.cpp
@@ -979,8 +979,7 @@ void BuildingLevel::draw(
   for (const auto& v : vertices)
     v.draw(
       scene,
-      vertex_radius / drawing_meters_per_pixel,
-      QColor::fromRgbF(0.0, 0.5, 0.0));
+      vertex_radius / drawing_meters_per_pixel);
 
   for (const auto& f : fiducials)
     f.draw(scene, drawing_meters_per_pixel);

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -87,7 +87,8 @@ Editor::Editor()
 
   map_view = new MapView(this);
   map_view->setScene(scene);
-  map_view->setStyleSheet("QToolTip { color: #000000; background-color: #ffff88; border: 0px; }");
+  map_view->setStyleSheet(
+    "QToolTip { color: #000000; background-color: #ffff88; border: 0px; }");
 
   QVBoxLayout* left_layout = new QVBoxLayout;
   left_layout->addWidget(map_view);

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -87,6 +87,7 @@ Editor::Editor()
 
   map_view = new MapView(this);
   map_view->setScene(scene);
+  map_view->setStyleSheet("QToolTip { color: #000000; background-color: #ffff88; border: 0px; }");
 
   QVBoxLayout* left_layout = new QVBoxLayout;
   left_layout->addWidget(map_view);
@@ -254,6 +255,8 @@ Editor::Editor()
   w->setLayout(hbox_layout);
   w->setStyleSheet("background-color: #404040");
   setCentralWidget(w);
+
+  //qApp->
 
   // PROJECT MENU
   QMenu* project_menu = menuBar()->addMenu("&Project");

--- a/traffic_editor/gui/scenario_level.cpp
+++ b/traffic_editor/gui/scenario_level.cpp
@@ -170,5 +170,5 @@ void ScenarioLevel::draw(
   draw_polygons(scene);
 
   for (const auto& v : vertices)
-    v.draw(scene, 0.1 / meters_per_pixel, QColor::fromRgbF(1.0, 1.0, 0.0));
+    v.draw(scene, 0.1 / meters_per_pixel);
 }

--- a/traffic_editor/gui/vertex.cpp
+++ b/traffic_editor/gui/vertex.cpp
@@ -133,7 +133,7 @@ void Vertex::draw(
 
   if (is_holding_point())
   {
-    const double icon_bearing = -45.0 * M_PI / 180.0;
+    const double icon_bearing = -135.0 * M_PI / 180.0;
     QIcon icon(":icons/stopwatch.svg");
     QPixmap pixmap(icon.pixmap(icon.actualSize(QSize(128, 128))));
     QGraphicsPixmapItem* pixmap_item = scene->addPixmap(pixmap);

--- a/traffic_editor/gui/vertex.cpp
+++ b/traffic_editor/gui/vertex.cpp
@@ -112,21 +112,54 @@ void Vertex::draw(
 
   QColor selected_color = QColor::fromRgbF(1.0, 0.0, 0.0, a);
 
-  scene->addEllipse(
-    x - radius,
-    y - radius,
-    2 * radius,
-    2 * radius,
-    vertex_pen,
-    selected ? QBrush(selected_color) : QBrush(nonselected_color));
+  const QBrush vertex_brush =
+    selected ? QBrush(selected_color) : QBrush(nonselected_color);
+
+  if (is_holding_point())
+  {
+    // draw the vertex as a slightly larger box
+    QGraphicsRectItem* rect_item = scene->addRect(
+      x - 1.5 * radius,
+      y - 1.5 * radius,
+      2 * 1.5 * radius,
+      2 * 1.5 * radius,
+      vertex_pen,
+      vertex_brush);
+    rect_item->setZValue(20.0);
+  }
+  else
+  {
+    // draw the vertex as a circle
+    QGraphicsEllipseItem* ellipse_item = scene->addEllipse(
+      x - radius,
+      y - radius,
+      2 * radius,
+      2 * radius,
+      vertex_pen,
+      vertex_brush);
+    ellipse_item->setZValue(20.0);  // above all lane/wall edges
+  }
+
+  if (is_parking_point())
+  {
+    // draw a larger black rectangle around the vertex
+    QGraphicsRectItem* rect_item = scene->addRect(
+      x - 2.5 * radius,
+      y - 2.5 * radius,
+      2 * 2.5 * radius,
+      2 * 2.5 * radius,
+      vertex_pen,
+      QBrush());  // transparent rectangle
+    rect_item->setZValue(20.0);
+  }
 
   if (!name.empty())
   {
-    QGraphicsSimpleTextItem* item = scene->addSimpleText(
+    QGraphicsSimpleTextItem* text_item = scene->addSimpleText(
       QString::fromStdString(name),
       QFont("Helvetica", 6));
-    item->setBrush(selected ? selected_color : color);
-    item->setPos(x, y + radius);
+    text_item->setBrush(selected ? selected_color : color);
+    text_item->setPos(x, y + radius);
   }
 }
 
@@ -139,4 +172,22 @@ void Vertex::set_param(const std::string& param_name, const std::string& value)
     return;  // unknown parameter
   }
   it->second.set(value);
+}
+
+bool Vertex::is_parking_point() const
+{
+  const auto it = params.find("is_parking_spot");
+  if (it == params.end())
+    return false;
+
+  return it->second.value_bool;
+}
+
+bool Vertex::is_holding_point() const
+{
+  const auto it = params.find("is_holding_point");
+  if (it == params.end())
+    return false;
+
+  return it->second.value_bool;
 }

--- a/traffic_editor/gui/vertex.cpp
+++ b/traffic_editor/gui/vertex.cpp
@@ -136,7 +136,7 @@ void Vertex::draw(
     const double icon_bearing = -45.0 * M_PI / 180.0;
     QIcon icon(":icons/stopwatch.svg");
     QPixmap pixmap(icon.pixmap(icon.actualSize(QSize(128, 128))));
-    QGraphicsPixmapItem *pixmap_item = scene->addPixmap(pixmap);
+    QGraphicsPixmapItem* pixmap_item = scene->addPixmap(pixmap);
     pixmap_item->setOffset(
       -pixmap.width() / 2,
       -pixmap.height() / 2);
@@ -152,7 +152,7 @@ void Vertex::draw(
     const double icon_bearing = 45.0 * M_PI / 180.0;
     QIcon icon(":icons/parking.svg");
     QPixmap pixmap(icon.pixmap(icon.actualSize(QSize(128, 128))));
-    QGraphicsPixmapItem *pixmap_item = scene->addPixmap(pixmap);
+    QGraphicsPixmapItem* pixmap_item = scene->addPixmap(pixmap);
     pixmap_item->setOffset(
       -pixmap.width() / 2,
       -pixmap.height() / 2);
@@ -191,7 +191,7 @@ void Vertex::draw(
     */
     QIcon battery_icon(":icons/battery.svg");
     QPixmap battery_pixmap(battery_icon.pixmap(battery_icon.actualSize(QSize(128, 128))));
-    QGraphicsPixmapItem *pixmap_item = scene->addPixmap(battery_pixmap);
+    QGraphicsPixmapItem* pixmap_item = scene->addPixmap(battery_pixmap);
     pixmap_item->setOffset(
       -battery_pixmap.width() / 2,
       -battery_pixmap.height() / 2);

--- a/traffic_editor/gui/vertex.cpp
+++ b/traffic_editor/gui/vertex.cpp
@@ -145,6 +145,7 @@ void Vertex::draw(
     pixmap_item->setPos(
       x + icon_ring_radius * cos(icon_bearing),
       y - icon_ring_radius * sin(icon_bearing));
+    pixmap_item->setToolTip("This vertex is a holding point");
   }
 
   if (is_parking_point())
@@ -161,6 +162,7 @@ void Vertex::draw(
     pixmap_item->setPos(
       x + icon_ring_radius * cos(icon_bearing),
       y - icon_ring_radius * sin(icon_bearing));
+    pixmap_item->setToolTip("This vertex is a parking point");
 
     /*
     // outline the vertex with another circle
@@ -177,7 +179,7 @@ void Vertex::draw(
 
   if (is_charger())
   {
-    const double charger_icon_bearing = 135.0 * M_PI / 180.0;
+    const double icon_bearing = 135.0 * M_PI / 180.0;
     /*
     // draw a larger black rectangle around the vertex
     QGraphicsRectItem* rect_item = scene->addRect(
@@ -189,17 +191,18 @@ void Vertex::draw(
       QBrush());  // default brush is transparent
     rect_item->setZValue(20.0);
     */
-    QIcon battery_icon(":icons/battery.svg");
-    QPixmap battery_pixmap(battery_icon.pixmap(battery_icon.actualSize(QSize(128, 128))));
-    QGraphicsPixmapItem* pixmap_item = scene->addPixmap(battery_pixmap);
+    QIcon icon(":icons/battery.svg");
+    QPixmap pixmap(icon.pixmap(icon.actualSize(QSize(128, 128))));
+    QGraphicsPixmapItem* pixmap_item = scene->addPixmap(pixmap);
     pixmap_item->setOffset(
-      -battery_pixmap.width() / 2,
-      -battery_pixmap.height() / 2);
+      -pixmap.width() / 2,
+      -pixmap.height() / 2);
     pixmap_item->setScale(icon_scale);
     pixmap_item->setZValue(20.0);
     pixmap_item->setPos(
-      x + icon_ring_radius * cos(charger_icon_bearing),
-      y - icon_ring_radius * sin(charger_icon_bearing));
+      x + icon_ring_radius * cos(icon_bearing),
+      y - icon_ring_radius * sin(icon_bearing));
+    pixmap_item->setToolTip("This vertex is a charger");
   }
 
   if (!name.empty())

--- a/traffic_editor/include/traffic_editor/vertex.h
+++ b/traffic_editor/include/traffic_editor/vertex.h
@@ -56,6 +56,9 @@ public:
     const double radius,
     const QColor& color) const;
 
+  bool is_parking_point() const;
+  bool is_holding_point() const;
+
   ////////////////////////////////////////////////////////////
   static const std::vector<std::pair<std::string, Param::Type>> allowed_params;
 };

--- a/traffic_editor/include/traffic_editor/vertex.h
+++ b/traffic_editor/include/traffic_editor/vertex.h
@@ -53,11 +53,11 @@ public:
 
   void draw(
     QGraphicsScene* scene,
-    const double radius,
-    const QColor& color) const;
+    const double radius) const;
 
   bool is_parking_point() const;
   bool is_holding_point() const;
+  bool is_charger() const;
 
   ////////////////////////////////////////////////////////////
   static const std::vector<std::pair<std::string, Param::Type>> allowed_params;

--- a/traffic_editor/resources/icons/battery.svg
+++ b/traffic_editor/resources/icons/battery.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 16.933334 16.933334"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="battery.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.4"
+     inkscape:cx="41.592262"
+     inkscape:cy="37.351366"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="3840"
+     inkscape:window-height="2160"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-280.06665)">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 4.764846,295.98856 v -12.48195 h 7.235399 l 0.01667,12.46136 z"
+       id="path815"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stroke-linecap:square"
+       id="rect821"
+       width="2.763751"
+       height="2.1810071"
+       x="7.1166835"
+       y="281.32397" />
+  </g>
+</svg>

--- a/traffic_editor/resources/icons/battery.svg
+++ b/traffic_editor/resources/icons/battery.svg
@@ -25,9 +25,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="22.4"
-     inkscape:cx="41.592262"
-     inkscape:cy="37.351366"
+     inkscape:zoom="7.919596"
+     inkscape:cx="37.327829"
+     inkscape:cy="32.664408"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      showgrid="false"
@@ -45,7 +45,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -55,13 +55,13 @@
      id="layer1"
      transform="translate(0,-280.06665)">
     <path
-       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#000000;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;fill-opacity:0.07843138"
        d="m 4.764846,295.98856 v -12.48195 h 7.235399 l 0.01667,12.46136 z"
        id="path815"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccccc" />
     <rect
-       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stroke-linecap:square"
+       style="fill:#000000;fill-opacity:0.07843138;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;stroke-linecap:square"
        id="rect821"
        width="2.763751"
        height="2.1810071"

--- a/traffic_editor/resources/icons/parking.svg
+++ b/traffic_editor/resources/icons/parking.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 16.933334 16.933334"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="parking.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.4"
+     inkscape:cx="26.401463"
+     inkscape:cy="26.608363"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="3840"
+     inkscape:window-height="2160"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-280.06665)">
+    <path
+       style="fill:#000000;stroke:none;stroke-width:1.50069714;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1"
+       d="M 1.4360371,295.73781 V 281.24122 H 15.466286 l 0.03233,14.47267 z"
+       id="path815"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 5.7523251,294.80299 v -11.67001 c 0,0 4.9183899,-0.32514 5.7877599,0.86227 0.465952,0.63641 0.746378,2.66935 -0.188982,3.77977 -1.26581,1.5027 -5.5279023,0.89773 -5.5279023,0.89773"
+       id="path816"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccssc" />
+  </g>
+</svg>

--- a/traffic_editor/resources/icons/stopwatch.svg
+++ b/traffic_editor/resources/icons/stopwatch.svg
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 16.933334 16.933334"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="stopwatch.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.839192"
+     inkscape:cx="35.033364"
+     inkscape:cy="38.966561"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1912"
+     inkscape:window-height="1318"
+     inkscape:window-x="1920"
+     inkscape:window-y="807"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-280.06665)">
+    <circle
+       style="fill:none;fill-opacity:1;stroke:#000020;stroke-width:1;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path814"
+       cx="8.4394989"
+       cy="288.91483"
+       r="5.392067" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.06337488;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 8.5464709,288.95583 v -3.90006"
+       id="path831"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.10231626;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 8.4820221,288.79628 3.4446709,-1.17092"
+       id="path833"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 10.949567,284.62782 1.688943,-2.16287"
+       id="path831-6"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 13.943216,283.57856 -2.774642,-2.0487"
+       id="path831-6-7"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 5.8125517,284.66409 -1.688942,-2.16287"
+       id="path831-6-5"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.8189027,283.61483 2.774642,-2.0487"
+       id="path831-6-7-3"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/traffic_editor/resources/icons/stopwatch.svg
+++ b/traffic_editor/resources/icons/stopwatch.svg
@@ -26,16 +26,16 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="15.839192"
-     inkscape:cx="35.033364"
+     inkscape:cx="22.02765"
      inkscape:cy="38.966561"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      showgrid="false"
      units="px"
-     inkscape:window-width="1912"
-     inkscape:window-height="1318"
-     inkscape:window-x="1920"
-     inkscape:window-y="807"
+     inkscape:window-width="3840"
+     inkscape:window-height="2160"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
      inkscape:window-maximized="0" />
   <metadata
      id="metadata5">
@@ -55,7 +55,7 @@
      id="layer1"
      transform="translate(0,-280.06665)">
     <circle
-       style="fill:none;fill-opacity:1;stroke:#000020;stroke-width:1;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#000000;fill-opacity:0.07843138;stroke:#000020;stroke-width:1;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path814"
        cx="8.4394989"
        cy="288.91483"

--- a/traffic_editor/resources/resource.qrc
+++ b/traffic_editor/resources/resource.qrc
@@ -1,16 +1,19 @@
 <!DOCTYPE RCC>
 <RCC version="1.0">
 <qresource>
-  <file>icons/vertex.svg</file>
-  <file>icons/move.svg</file>
-  <file>icons/rotate.svg</file>
-  <file>icons/select.svg</file>
+  <file>icons/battery.svg</file>
+  <file>icons/door.svg</file>
   <file>icons/fiducial.svg</file>
-  <file>icons/roi.svg</file>
   <file>icons/floor.svg</file>
   <file>icons/hole.svg</file>
-  <file>icons/wall.svg</file>
-  <file>icons/door.svg</file>
   <file>icons/measurement.svg</file>
+  <file>icons/move.svg</file>
+  <file>icons/parking.svg</file>
+  <file>icons/roi.svg</file>
+  <file>icons/rotate.svg</file>
+  <file>icons/select.svg</file>
+  <file>icons/stopwatch.svg</file>
+  <file>icons/vertex.svg</file>
+  <file>icons/wall.svg</file>
 </qresource>
 </RCC>


### PR DESCRIPTION
This PR changes the shape of vertex icons to indicate if they are set to be holding and/or parking points in the navigation graph.

 * holding points will be rendered as slightly larger squares
 * parking points will have an outline of an even-larger square
 * otherwise the vertex will be rendered as a circle, as before.


Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>