### PR TITLE
Add UI for adding correspondence points

### DIFF
--- a/traffic_editor/CMakeLists.txt
+++ b/traffic_editor/CMakeLists.txt
@@ -37,6 +37,7 @@ include_directories(include)
 include_directories(${ament_index_cpp_INCLUDE_DIRS})
 
 set(traffic_editor_sources
+  gui/actions/add_correspondence_point.cpp
   gui/actions/add_edge.cpp
   gui/actions/add_fiducial.cpp
   gui/actions/add_model.cpp
@@ -44,6 +45,7 @@ set(traffic_editor_sources
   gui/actions/add_property.cpp
   gui/actions/add_vertex.cpp
   gui/actions/delete.cpp
+  gui/actions/move_correspondence_point.cpp
   gui/actions/move_fiducial.cpp
   gui/actions/move_model.cpp
   gui/actions/move_vertex.cpp
@@ -56,6 +58,7 @@ set(traffic_editor_sources
   gui/building_level.cpp
   gui/building_level_dialog.cpp
   gui/building_level_table.cpp
+  gui/correspondence_point.cpp
   gui/edge.cpp
   gui/editor.cpp
   gui/editor_model.cpp

--- a/traffic_editor/gui/actions/add_correspondence_point.cpp
+++ b/traffic_editor/gui/actions/add_correspondence_point.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2019-2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "add_correspondence_point.hpp"
+
+AddCorrespondencePointCommand::AddCorrespondencePointCommand(
+  Project* project,
+  int level,
+  int layer,
+  double x,
+  double y)
+: project_(project),
+  level_(level),
+  layer_(layer),
+  x_(x),
+  y_(y)
+{
+}
+
+void AddCorrespondencePointCommand::undo()
+{
+  int index_to_remove = -1;
+
+  for (
+    size_t ii = 0;
+    ii < project_->building.levels[level_].layers[layer_].correspondence_points.size();
+    ++ii)
+  {
+    if (uuid_ ==
+        project_->building.levels[level_].layers[layer_].correspondence_points[ii].uuid())
+    {
+      index_to_remove = ii;
+    }
+  }
+  if (index_to_remove < 0) {
+    return;
+  }
+
+  project_->building.levels[level_].layers[layer_].correspondence_points.erase(
+    project_->building.levels[level_].layers[layer_].correspondence_points.begin() +
+      index_to_remove);
+}
+
+void AddCorrespondencePointCommand::redo()
+{
+  uuid_ = project_->building.add_correspondence_point(level_, layer_, x_, y_);
+}
+

--- a/traffic_editor/gui/actions/add_correspondence_point.cpp
+++ b/traffic_editor/gui/actions/add_correspondence_point.cpp
@@ -34,25 +34,19 @@ AddCorrespondencePointCommand::AddCorrespondencePointCommand(
 void AddCorrespondencePointCommand::undo()
 {
   int index_to_remove = -1;
+  auto& s = project_->building.levels[level_].
+    correspondence_point_sets()[layer_];
 
-  for (
-    size_t ii = 0;
-    ii < project_->building.levels[level_].correspondence_point_sets()[layer_].size();
-    ++ii)
+  for (size_t ii = 0; ii < s.size(); ++ii)
   {
-    if (uuid_ ==
-        project_->building.levels[level_].correspondence_point_sets()[layer_][ii].uuid())
-    {
+    if (uuid_ == s[ii].uuid())
       index_to_remove = ii;
-    }
   }
   if (index_to_remove < 0) {
     return;
   }
 
-  project_->building.levels[level_].correspondence_point_sets()[layer_].erase(
-    project_->building.levels[level_].correspondence_point_sets()[layer_].begin() +
-      index_to_remove);
+  s.erase(s.begin() + index_to_remove);
 }
 
 void AddCorrespondencePointCommand::redo()

--- a/traffic_editor/gui/actions/add_correspondence_point.cpp
+++ b/traffic_editor/gui/actions/add_correspondence_point.cpp
@@ -42,7 +42,8 @@ void AddCorrespondencePointCommand::undo()
     if (uuid_ == s[ii].uuid())
       index_to_remove = ii;
   }
-  if (index_to_remove < 0) {
+  if (index_to_remove < 0)
+  {
     return;
   }
 

--- a/traffic_editor/gui/actions/add_correspondence_point.cpp
+++ b/traffic_editor/gui/actions/add_correspondence_point.cpp
@@ -37,11 +37,11 @@ void AddCorrespondencePointCommand::undo()
 
   for (
     size_t ii = 0;
-    ii < project_->building.levels[level_].layers[layer_].correspondence_points.size();
+    ii < project_->building.levels[level_].correspondence_point_sets()[layer_].size();
     ++ii)
   {
     if (uuid_ ==
-        project_->building.levels[level_].layers[layer_].correspondence_points[ii].uuid())
+        project_->building.levels[level_].correspondence_point_sets()[layer_][ii].uuid())
     {
       index_to_remove = ii;
     }
@@ -50,8 +50,8 @@ void AddCorrespondencePointCommand::undo()
     return;
   }
 
-  project_->building.levels[level_].layers[layer_].correspondence_points.erase(
-    project_->building.levels[level_].layers[layer_].correspondence_points.begin() +
+  project_->building.levels[level_].correspondence_point_sets()[layer_].erase(
+    project_->building.levels[level_].correspondence_point_sets()[layer_].begin() +
       index_to_remove);
 }
 

--- a/traffic_editor/gui/actions/add_correspondence_point.hpp
+++ b/traffic_editor/gui/actions/add_correspondence_point.hpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef ACTIONS__ADD_CORRESPONDENCE_POINT_HPP_
+#define ACTIONS__ADD_CORRESPONDENCE_POINT_HPP_
+
+#include <QUndoCommand>
+#include <QUuid>
+
+#include "project.h"
+
+class AddCorrespondencePointCommand : public QUndoCommand
+{
+public:
+  AddCorrespondencePointCommand(Project* project, int level, int layer, double x, double y);
+
+  void undo() override;
+  void redo() override;
+
+private:
+  Project* project_;
+  int level_, layer_;
+  double x_, y_;
+  QUuid uuid_;
+};
+
+#endif  // ACTIONS__ADD_CORRESPONDENCE_POINT_HPP_

--- a/traffic_editor/gui/actions/add_correspondence_point.hpp
+++ b/traffic_editor/gui/actions/add_correspondence_point.hpp
@@ -26,7 +26,12 @@
 class AddCorrespondencePointCommand : public QUndoCommand
 {
 public:
-  AddCorrespondencePointCommand(Project* project, int level, int layer, double x, double y);
+  AddCorrespondencePointCommand(
+    Project* project,
+    int level,
+    int layer,
+    double x,
+    double y);
 
   void undo() override;
   void redo() override;

--- a/traffic_editor/gui/actions/move_correspondence_point.cpp
+++ b/traffic_editor/gui/actions/move_correspondence_point.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "move_correspondence_point.hpp"
+
+MoveCorrespondencePointCommand::MoveCorrespondencePointCommand(
+  Project* project,
+  int level,
+  int layer,
+  int point_id)
+: has_moved(false),
+  project_(project),
+  level_(level),
+  layer_(layer),
+  point_id_(point_id)
+{
+  CorrespondencePoint correspondence_point =
+    project_->building.levels[level_].layers[layer_].correspondence_points[point_id_];
+  final_x_ = original_x_ = correspondence_point.x();
+  final_y_ = original_y_ = correspondence_point.y();
+}
+
+void MoveCorrespondencePointCommand::undo()
+{
+  CorrespondencePoint& correspondence_point =
+    project_->building.levels[level_].layers[layer_].correspondence_points[point_id_];
+  correspondence_point.set_x(original_x_);
+  correspondence_point.set_y(original_y_);
+}
+
+void MoveCorrespondencePointCommand::redo()
+{
+  CorrespondencePoint& correspondence_point =
+    project_->building.levels[level_].layers[layer_].correspondence_points[point_id_];
+  correspondence_point.set_x(final_x_);
+  correspondence_point.set_y(final_y_);
+}
+
+void MoveCorrespondencePointCommand::set_final_destination(double x, double y)
+{
+  final_x_ = x;
+  final_y_ = y;
+  has_moved = true;
+}
+

--- a/traffic_editor/gui/actions/move_correspondence_point.cpp
+++ b/traffic_editor/gui/actions/move_correspondence_point.cpp
@@ -29,7 +29,7 @@ MoveCorrespondencePointCommand::MoveCorrespondencePointCommand(
   point_id_(point_id)
 {
   CorrespondencePoint correspondence_point =
-    project_->building.levels[level_].layers[layer_].correspondence_points[point_id_];
+    project_->building.levels[level_].correspondence_point_sets()[layer_][point_id_];
   final_x_ = original_x_ = correspondence_point.x();
   final_y_ = original_y_ = correspondence_point.y();
 }
@@ -37,7 +37,7 @@ MoveCorrespondencePointCommand::MoveCorrespondencePointCommand(
 void MoveCorrespondencePointCommand::undo()
 {
   CorrespondencePoint& correspondence_point =
-    project_->building.levels[level_].layers[layer_].correspondence_points[point_id_];
+    project_->building.levels[level_].correspondence_point_sets()[layer_][point_id_];
   correspondence_point.set_x(original_x_);
   correspondence_point.set_y(original_y_);
 }
@@ -45,7 +45,7 @@ void MoveCorrespondencePointCommand::undo()
 void MoveCorrespondencePointCommand::redo()
 {
   CorrespondencePoint& correspondence_point =
-    project_->building.levels[level_].layers[layer_].correspondence_points[point_id_];
+    project_->building.levels[level_].correspondence_point_sets()[layer_][point_id_];
   correspondence_point.set_x(final_x_);
   correspondence_point.set_y(final_y_);
 }

--- a/traffic_editor/gui/actions/move_correspondence_point.cpp
+++ b/traffic_editor/gui/actions/move_correspondence_point.cpp
@@ -29,7 +29,8 @@ MoveCorrespondencePointCommand::MoveCorrespondencePointCommand(
   point_id_(point_id)
 {
   CorrespondencePoint correspondence_point =
-    project_->building.levels[level_].correspondence_point_sets()[layer_][point_id_];
+    project_->building.levels[level_].
+    correspondence_point_sets()[layer_][point_id_];
   final_x_ = original_x_ = correspondence_point.x();
   final_y_ = original_y_ = correspondence_point.y();
 }
@@ -37,7 +38,8 @@ MoveCorrespondencePointCommand::MoveCorrespondencePointCommand(
 void MoveCorrespondencePointCommand::undo()
 {
   CorrespondencePoint& correspondence_point =
-    project_->building.levels[level_].correspondence_point_sets()[layer_][point_id_];
+    project_->building.levels[level_].
+    correspondence_point_sets()[layer_][point_id_];
   correspondence_point.set_x(original_x_);
   correspondence_point.set_y(original_y_);
 }
@@ -45,7 +47,8 @@ void MoveCorrespondencePointCommand::undo()
 void MoveCorrespondencePointCommand::redo()
 {
   CorrespondencePoint& correspondence_point =
-    project_->building.levels[level_].correspondence_point_sets()[layer_][point_id_];
+    project_->building.levels[level_].
+    correspondence_point_sets()[layer_][point_id_];
   correspondence_point.set_x(final_x_);
   correspondence_point.set_y(final_y_);
 }
@@ -56,4 +59,3 @@ void MoveCorrespondencePointCommand::set_final_destination(double x, double y)
   final_y_ = y;
   has_moved = true;
 }
-

--- a/traffic_editor/gui/actions/move_correspondence_point.hpp
+++ b/traffic_editor/gui/actions/move_correspondence_point.hpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef ACTIONS__MOVE_CORRESPONDENCE_POING_HPP_
+#define ACTIONS__MOVE_CORRESPONDENCE_POING_HPP_
+
+#include <QUndoCommand>
+#include <QUuid>
+
+#include "project.h"
+
+class MoveCorrespondencePointCommand : public QUndoCommand
+{
+public:
+  MoveCorrespondencePointCommand(Project* project, int id, int level, int layer);
+
+  void undo() override;
+  void redo() override;
+
+  void set_final_destination(double x, double y);
+
+  bool has_moved;
+
+private:
+  Project* project_;
+  int level_, layer_, point_id_;
+  double original_x_, original_y_;
+  double final_x_, final_y_;
+};
+
+#endif  // ACTIONS__MOVE_CORRESPONDENCE_POING_HPP_

--- a/traffic_editor/gui/actions/move_correspondence_point.hpp
+++ b/traffic_editor/gui/actions/move_correspondence_point.hpp
@@ -26,7 +26,11 @@
 class MoveCorrespondencePointCommand : public QUndoCommand
 {
 public:
-  MoveCorrespondencePointCommand(Project* project, int id, int level, int layer);
+  MoveCorrespondencePointCommand(
+    Project* project,
+    int id,
+    int level,
+    int layer);
 
   void undo() override;
   void redo() override;

--- a/traffic_editor/gui/building.cpp
+++ b/traffic_editor/gui/building.cpp
@@ -167,7 +167,9 @@ bool Building::save_yaml_file()
   return true;
 }
 
-bool Building::export_level_correspondence_points(int level_index, const std::string& dest_filename) const
+bool Building::export_level_correspondence_points(
+  int level_index,
+  const std::string& dest_filename) const
 {
   return levels[level_index].export_correspondence_points(dest_filename);
 }
@@ -187,11 +189,16 @@ QUuid Building::add_fiducial(int level_index, double x, double y)
   return levels[level_index].fiducials.rbegin()->uuid;
 }
 
-QUuid Building::add_correspondence_point(int level, int layer, double x, double y)
+QUuid Building::add_correspondence_point(
+  int level,
+  int layer,
+  double x,
+  double y)
 {
   if (level >= static_cast<int>(levels.size()))
     return NULL;
-  if (layer >= static_cast<int>(levels[level].correspondence_point_sets().size()))
+  if (layer >=
+    static_cast<int>(levels[level].correspondence_point_sets().size()))
     return NULL;
   return levels[level].add_correspondence_point(layer, x, y);
 }
@@ -248,7 +255,8 @@ Building::NearestItem Building::nearest_items(
     ii < level.correspondence_point_sets()[layer_index].size();
     ++ii)
   {
-    const CorrespondencePoint& cp = level.correspondence_point_sets()[layer_index][ii];
+    const CorrespondencePoint& cp =
+      level.correspondence_point_sets()[layer_index][ii];
     const double dx = x - cp.x();
     const double dy = y - cp.y();
     const double dist = sqrt(dx*dx + dy*dy);

--- a/traffic_editor/gui/building.cpp
+++ b/traffic_editor/gui/building.cpp
@@ -189,12 +189,10 @@ QUuid Building::add_fiducial(int level_index, double x, double y)
 
 QUuid Building::add_correspondence_point(int level, int layer, double x, double y)
 {
-  if (level >= static_cast<int>(levels.size())) {
+  if (level >= static_cast<int>(levels.size()))
     return NULL;
-  }
-  if (layer >= static_cast<int>(levels[level].correspondence_point_sets().size())) {
+  if (layer >= static_cast<int>(levels[level].correspondence_point_sets().size()))
     return NULL;
-  }
   return levels[level].add_correspondence_point(layer, x, y);
 }
 
@@ -246,7 +244,9 @@ Building::NearestItem Building::nearest_items(
     }
   }
 
-  for (size_t ii = 0; ii < level.correspondence_point_sets()[layer_index].size(); ++ii)
+  for (size_t ii = 0;
+    ii < level.correspondence_point_sets()[layer_index].size();
+    ++ii)
   {
     const CorrespondencePoint& cp = level.correspondence_point_sets()[layer_index][ii];
     const double dx = x - cp.x();

--- a/traffic_editor/gui/building.cpp
+++ b/traffic_editor/gui/building.cpp
@@ -167,6 +167,11 @@ bool Building::save_yaml_file()
   return true;
 }
 
+bool Building::export_level_correspondence_points(int level_index, const std::string& dest_filename) const
+{
+  return levels[level_index].export_correspondence_points(dest_filename);
+}
+
 void Building::add_vertex(int level_index, double x, double y)
 {
   if (level_index >= static_cast<int>(levels.size()))

--- a/traffic_editor/gui/building.cpp
+++ b/traffic_editor/gui/building.cpp
@@ -182,6 +182,18 @@ QUuid Building::add_fiducial(int level_index, double x, double y)
   return levels[level_index].fiducials.rbegin()->uuid;
 }
 
+QUuid Building::add_correspondence_point(int level, int layer, double x, double y)
+{
+  if (level >= static_cast<int>(levels.size())) {
+    return NULL;
+  }
+  if (layer >= static_cast<int>(levels[level].layers.size())) {
+    return NULL;
+  }
+  levels[level].layers[layer].correspondence_points.push_back(CorrespondencePoint(x, y));
+  return levels[level].layers[layer].correspondence_points.rbegin()->uuid();
+}
+
 int Building::find_nearest_vertex_index(
   int level_index,
   double x,
@@ -208,6 +220,7 @@ int Building::find_nearest_vertex_index(
 
 Building::NearestItem Building::nearest_items(
   const int level_index,
+  const int layer_index,
   const double x,
   const double y)
 {
@@ -226,6 +239,19 @@ Building::NearestItem Building::nearest_items(
     {
       ni.vertex_dist = dist;
       ni.vertex_idx = i;
+    }
+  }
+
+  for (size_t ii = 0; ii < level.layers[layer_index].correspondence_points.size(); ++ii)
+  {
+    const CorrespondencePoint& cp = level.layers[layer_index].correspondence_points[ii];
+    const double dx = x - cp.x();
+    const double dy = y - cp.y();
+    const double dist = sqrt(dx*dx + dy*dy);
+    if (dist < ni.correspondence_point_dist)
+    {
+      ni.correspondence_point_dist = dist;
+      ni.correspondence_point_idx = ii;
     }
   }
 

--- a/traffic_editor/gui/building.cpp
+++ b/traffic_editor/gui/building.cpp
@@ -187,11 +187,10 @@ QUuid Building::add_correspondence_point(int level, int layer, double x, double 
   if (level >= static_cast<int>(levels.size())) {
     return NULL;
   }
-  if (layer >= static_cast<int>(levels[level].layers.size())) {
+  if (layer >= static_cast<int>(levels[level].correspondence_point_sets().size())) {
     return NULL;
   }
-  levels[level].layers[layer].correspondence_points.push_back(CorrespondencePoint(x, y));
-  return levels[level].layers[layer].correspondence_points.rbegin()->uuid();
+  return levels[level].add_correspondence_point(layer, x, y);
 }
 
 int Building::find_nearest_vertex_index(
@@ -242,9 +241,9 @@ Building::NearestItem Building::nearest_items(
     }
   }
 
-  for (size_t ii = 0; ii < level.layers[layer_index].correspondence_points.size(); ++ii)
+  for (size_t ii = 0; ii < level.correspondence_point_sets()[layer_index].size(); ++ii)
   {
-    const CorrespondencePoint& cp = level.layers[layer_index].correspondence_points[ii];
+    const CorrespondencePoint& cp = level.correspondence_point_sets()[layer_index][ii];
     const double dx = x - cp.x();
     const double dy = y - cp.y();
     const double dist = sqrt(dx*dx + dy*dy);

--- a/traffic_editor/gui/building_level.cpp
+++ b/traffic_editor/gui/building_level.cpp
@@ -149,27 +149,33 @@ bool BuildingLevel::from_yaml(
     }
   }
 
-  if (_data["correspondence_point_sets"] && _data["correspondence_point_sets"].IsSequence()) {
+  if (_data["correspondence_point_sets"] &&
+    _data["correspondence_point_sets"].IsSequence())
+  {
     const YAML::Node& node = _data["correspondence_point_sets"];
-    for (YAML::const_iterator ii = node.begin(); ii != node.end(); ++ii) {
+    for (YAML::const_iterator ii = node.begin(); ii != node.end(); ++ii)
+    {
       std::vector<CorrespondencePoint> cps;
-      for (YAML::const_iterator jj = ii->begin(); jj != ii->end(); ++jj) {
+      for (YAML::const_iterator jj = ii->begin(); jj != ii->end(); ++jj)
+      {
         CorrespondencePoint cp;
         cp.from_yaml(*jj);
         cps.push_back(cp);
       }
       correspondence_point_sets_.push_back(cps);
-      if (cps.size() > 0) {
+      if (cps.size() > 0)
         next_cp_ids.push_back(cps.rbegin()->id() + 1);
-      } else {
+      else
         next_cp_ids.push_back(0);
-      }
     }
-  } else {
+  }
+  else
+  {
     // Add an empty set for each layer, including the floorplan non-layer
     correspondence_point_sets_.push_back(std::vector<CorrespondencePoint>());
     next_cp_ids.push_back(0);
-    for (size_t ii = 0; ii < layers.size(); ++ii) {
+    for (size_t ii = 0; ii < layers.size(); ++ii)
+    {
       correspondence_point_sets_.push_back(std::vector<CorrespondencePoint>());
       next_cp_ids.push_back(0);
     }
@@ -1042,7 +1048,8 @@ QUuid BuildingLevel::add_correspondence_point(int layer, double x, double y)
   return correspondence_point_sets_[layer].rbegin()->uuid();
 }
 
-bool BuildingLevel::export_correspondence_points(const std::string& filename) const
+bool BuildingLevel::export_correspondence_points(
+  const std::string& filename) const
 {
   YAML::Node level_correspondence_points;
 
@@ -1053,7 +1060,8 @@ bool BuildingLevel::export_correspondence_points(const std::string& filename) co
   floorplan_yaml["size"].push_back(drawing_height);
   floorplan_yaml["size"].SetStyle(YAML::EmitterStyle::Flow);
   YAML::Node floorplan_cps;
-  for (const auto& cp : correspondence_point_sets_[0]) {
+  for (const auto& cp : correspondence_point_sets_[0])
+  {
     YAML::Node cp_yaml;
     cp_yaml.SetStyle(YAML::EmitterStyle::Flow);
     cp_yaml.push_back(cp.x());
@@ -1064,13 +1072,17 @@ bool BuildingLevel::export_correspondence_points(const std::string& filename) co
   level_correspondence_points["ref_map"] = floorplan_yaml;
 
   int layer_index = 1;
-  for (std::vector<Layer>::const_iterator layer = layers.begin(); layer != layers.end(); ++layer) {
+  for (std::vector<Layer>::const_iterator layer = layers.begin();
+    layer != layers.end();
+    ++layer)
+  {
     YAML::Node y;
     y["name"] = layer->name;
     y["image_file"] = layer->filename;
 
     QPixmap layer_pixmap =
-      QPixmap::fromImage(QImageReader(QString::fromStdString(layer->filename)).read());
+      QPixmap::fromImage(
+        QImageReader(QString::fromStdString(layer->filename)).read());
     y["size"].push_back(layer_pixmap.width());
     y["size"].push_back(layer_pixmap.height());
     y["size"].SetStyle(YAML::EmitterStyle::Flow);
@@ -1081,15 +1093,19 @@ bool BuildingLevel::export_correspondence_points(const std::string& filename) co
     transform["scale"].push_back(scale);
     transform["scale"].SetStyle(YAML::EmitterStyle::Flow);
     transform["rotation"] = layer->rotation;
-    transform["translation"].push_back((layer->translation_x / drawing_meters_per_pixel) / scale);
-    transform["translation"].push_back((layer->translation_y / drawing_meters_per_pixel) / scale);
+    transform["translation"].push_back(
+      (layer->translation_x / drawing_meters_per_pixel) / scale);
+    transform["translation"].push_back(
+      (layer->translation_y / drawing_meters_per_pixel) / scale);
     transform["translation"].SetStyle(YAML::EmitterStyle::Flow);
     y["transform"] = transform;
 
     YAML::Node cps;
-    for (const auto& cp : correspondence_point_sets_[layer_index]) {
+    for (const auto& cp : correspondence_point_sets_[layer_index])
+    {
       QPointF offset = layer->scene_item->offset();
-      QPointF mapped_point = layer->scene_item->mapFromScene(QPointF(cp.x(), cp.y()));
+      QPointF mapped_point =
+        layer->scene_item->mapFromScene(QPointF(cp.x(), cp.y()));
       YAML::Node cp_yaml;
       cp_yaml.push_back(mapped_point.rx() - offset.rx());
       cp_yaml.push_back(mapped_point.ry() - offset.ry());

--- a/traffic_editor/gui/building_level.cpp
+++ b/traffic_editor/gui/building_level.cpp
@@ -233,11 +233,11 @@ YAML::Node BuildingLevel::to_yaml() const
   for (const auto& v : vertices)
     y["vertices"].push_back(v.to_yaml());
 
-  for (const auto& cps : correspondence_point_sets_) {
+  for (const auto& cps : correspondence_point_sets_)
+  {
     YAML::Node set;
-    for (const auto& cp : cps) {
+    for (const auto& cp : cps)
       set.push_back(cp.to_yaml());
-    }
     y["correspondence_point_sets"].push_back(set);
   }
 
@@ -1080,9 +1080,8 @@ bool BuildingLevel::export_correspondence_points(
     y["name"] = layer->name;
     y["image_file"] = layer->filename;
 
-    QPixmap layer_pixmap =
-      QPixmap::fromImage(
-        QImageReader(QString::fromStdString(layer->filename)).read());
+    QPixmap layer_pixmap = QPixmap::fromImage(
+      QImageReader(QString::fromStdString(layer->filename)).read());
     y["size"].push_back(layer_pixmap.width());
     y["size"].push_back(layer_pixmap.height());
     y["size"].SetStyle(YAML::EmitterStyle::Flow);
@@ -1164,7 +1163,8 @@ bool BuildingLevel::export_correspondence_points(
   return true;
 }
 
-void BuildingLevel::layer_added() {
+void BuildingLevel::layer_added()
+{
   correspondence_point_sets_.push_back(std::vector<CorrespondencePoint>());
   next_cp_ids.push_back(0);
 }

--- a/traffic_editor/gui/building_level.cpp
+++ b/traffic_editor/gui/building_level.cpp
@@ -918,7 +918,7 @@ void BuildingLevel::draw(
   vector<EditorModel>& editor_models,
   const RenderingOptions& rendering_options)
 {
-  if (drawing_filename.size())
+  if (drawing_filename.size() && drawing_visible_)
   {
     scene->setSceneRect(
       QRectF(0, 0, drawing_width, drawing_height));

--- a/traffic_editor/gui/correspondence_point.cpp
+++ b/traffic_editor/gui/correspondence_point.cpp
@@ -72,7 +72,7 @@ void CorrespondencePoint::draw(QGraphicsScene* scene, double meters_per_pixel) c
 
   QGraphicsSimpleTextItem* item = scene->addSimpleText(QString::number(id_));
   item->setBrush(QColor(0, 0, 255, 255));
-  item->setPos(x_ + radius, y_ + radius);
+  item->setPos(x_, y_ + radius);
   auto font = item->font();
   font.setPointSize(30);
   item->setFont(font);

--- a/traffic_editor/gui/correspondence_point.cpp
+++ b/traffic_editor/gui/correspondence_point.cpp
@@ -24,17 +24,14 @@
 #include "traffic_editor/correspondence_point.hpp"
 
 
-uint16_t CorrespondencePoint::next_id_ = 0;
-
 CorrespondencePoint::CorrespondencePoint()
 {
   uuid_ = QUuid::createUuid();
 }
 
-CorrespondencePoint::CorrespondencePoint(double x, double y)
-: x_(x), y_(y)
+CorrespondencePoint::CorrespondencePoint(double x, double y, int id)
+: x_(x), y_(y), id_(id)
 {
-  id_ = next_id_++;
   uuid_ = QUuid::createUuid();
 }
 
@@ -73,8 +70,10 @@ void CorrespondencePoint::draw(QGraphicsScene* scene, double meters_per_pixel) c
   scene->addLine(x_ - 2 * radius, y_ - 2 * radius, x_ + 2 * radius, y_ + 2 * radius, pen);
   scene->addLine(x_ - 2 * radius, y_ + 2 * radius, x_ + 2 * radius, y_ - 2 * radius, pen);
 
-  QGraphicsSimpleTextItem* item = scene->addSimpleText(
-    QString::number(id_));
+  QGraphicsSimpleTextItem* item = scene->addSimpleText(QString::number(id_));
   item->setBrush(QColor(0, 0, 255, 255));
   item->setPos(x_ + radius, y_ + radius);
+  auto font = item->font();
+  font.setPointSize(30);
+  item->setFont(font);
 }

--- a/traffic_editor/gui/correspondence_point.cpp
+++ b/traffic_editor/gui/correspondence_point.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <cmath>
+
+#include <QGraphicsScene>
+#include <QGraphicsSimpleTextItem>
+#include <QString>
+
+#include "traffic_editor/correspondence_point.hpp"
+
+
+uint16_t CorrespondencePoint::next_id_ = 0;
+
+CorrespondencePoint::CorrespondencePoint()
+{
+  uuid_ = QUuid::createUuid();
+}
+
+CorrespondencePoint::CorrespondencePoint(double x, double y)
+: x_(x), y_(y)
+{
+  id_ = next_id_++;
+  uuid_ = QUuid::createUuid();
+}
+
+void CorrespondencePoint::from_yaml(const YAML::Node& data)
+{
+  if (!data.IsMap()) {
+    throw std::runtime_error("CorrespondencePoint::from_yaml() expected a map");
+  }
+  x_ = data["x"].as<double>();
+  y_ = data["y"].as<double>();
+  id_ = data["id"].as<uint16_t>();
+  uuid_ = QString(data["uuid"].as<std::string>().c_str());
+}
+
+YAML::Node CorrespondencePoint::to_yaml() const
+{
+  YAML::Node node;
+  node.SetStyle(YAML::EmitterStyle::Flow);
+  node["x"] = std::round(x_ * 1000.0) / 1000.0;
+  node["y"] = std::round(y_ * 1000.0) / 1000.0;
+  node["id"] = id_;
+  node["uuid"] = uuid_.toString().toStdString();
+  return node;
+}
+
+void CorrespondencePoint::draw(QGraphicsScene* scene, double meters_per_pixel) const
+{
+  const double a = 0.5;
+  const QColor color = QColor::fromRgbF(0.0, 0.0, 1.0, a);
+  const QColor selected_color = QColor::fromRgbF(1.0, 0.0, 0.0, a);
+
+  QPen pen(selected_ ? selected_color : color);
+  pen.setWidth(0.2 / meters_per_pixel);
+  const double radius = 0.5 / meters_per_pixel;
+
+  scene->addLine(x_ - 2 * radius, y_ - 2 * radius, x_ + 2 * radius, y_ + 2 * radius, pen);
+  scene->addLine(x_ - 2 * radius, y_ + 2 * radius, x_ + 2 * radius, y_ - 2 * radius, pen);
+
+  QGraphicsSimpleTextItem* item = scene->addSimpleText(
+    QString::number(id_));
+  item->setBrush(QColor(0, 0, 255, 255));
+  item->setPos(x_ + radius, y_ + radius);
+}

--- a/traffic_editor/gui/correspondence_point.cpp
+++ b/traffic_editor/gui/correspondence_point.cpp
@@ -37,9 +37,8 @@ CorrespondencePoint::CorrespondencePoint(double x, double y, int id)
 
 void CorrespondencePoint::from_yaml(const YAML::Node& data)
 {
-  if (!data.IsMap()) {
+  if (!data.IsMap())
     throw std::runtime_error("CorrespondencePoint::from_yaml() expected a map");
-  }
   x_ = data["x"].as<double>();
   y_ = data["y"].as<double>();
   id_ = data["id"].as<uint16_t>();
@@ -57,7 +56,9 @@ YAML::Node CorrespondencePoint::to_yaml() const
   return node;
 }
 
-void CorrespondencePoint::draw(QGraphicsScene* scene, double meters_per_pixel) const
+void CorrespondencePoint::draw(
+  QGraphicsScene* scene,
+  double meters_per_pixel) const
 {
   const double a = 0.5;
   const QColor color = QColor::fromRgbF(0.0, 0.0, 1.0, a);
@@ -67,8 +68,19 @@ void CorrespondencePoint::draw(QGraphicsScene* scene, double meters_per_pixel) c
   pen.setWidth(0.2 / meters_per_pixel);
   const double radius = 0.5 / meters_per_pixel;
 
-  scene->addLine(x_ - 2 * radius, y_ - 2 * radius, x_ + 2 * radius, y_ + 2 * radius, pen);
-  scene->addLine(x_ - 2 * radius, y_ + 2 * radius, x_ + 2 * radius, y_ - 2 * radius, pen);
+  scene->addLine(
+    x_ - 2 * radius,
+    y_ - 2 * radius,
+    x_ + 2 * radius,
+    y_ + 2 * radius,
+    pen);
+
+  scene->addLine(
+    x_ - 2 * radius,
+    y_ + 2 * radius,
+    x_ + 2 * radius,
+    y_ - 2 * radius,
+    pen);
 
   QGraphicsSimpleTextItem* item = scene->addSimpleText(QString::number(id_));
   item->setBrush(QColor(0, 0, 255, 255));

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -287,6 +287,12 @@ Editor::Editor()
     &Editor::project_save,
     QKeySequence(Qt::CTRL + Qt::Key_S));
 
+  project_menu->addAction(
+    "&Export correspondence points for level",
+    this,
+    &Editor::project_export_correspondence_points,
+    QKeySequence(Qt::CTRL + Qt::Key_E));
+
   project_menu->addSeparator();
 
   project_menu->addAction(
@@ -806,6 +812,26 @@ bool Editor::project_save()
   project.save();
   setWindowModified(false);
   return true;
+}
+
+bool Editor::project_export_correspondence_points()
+{
+  QFileDialog dialog(this, "Export correspondence points for level");
+  dialog.setNameFilter("*.yaml");
+  dialog.setDefaultSuffix(".yaml");
+  dialog.setAcceptMode(QFileDialog::AcceptMode::AcceptSave);
+  dialog.setConfirmOverwrite(true);
+
+  if (dialog.exec() != QDialog::Accepted) {
+    return true;
+  }
+
+  QFileInfo file_info(dialog.selectedFiles().first());
+  auto result = project.export_correspondence_points(
+    level_idx,
+    file_info.absoluteFilePath().toStdString());
+  setWindowModified(false);
+  return result;
 }
 
 void Editor::help_about()
@@ -1413,6 +1439,7 @@ void Editor::layer_add_button_clicked()
     return;
   printf("added a layer: [%s]\n", layer.name.c_str());
   level.layers.push_back(layer);
+  level.layer_added();
   populate_layers_table();
   setWindowModified(true);
 }

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -100,7 +100,9 @@ Editor::Editor()
   connect(
     layers_table, &QTableWidget::cellClicked,
     [=](int row, int /*col*/) {
-      if (row < static_cast<int>(project.building.levels[level_idx].layers.size())) {
+      if (row < static_cast<int>(
+        project.building.levels[level_idx].layers.size()))
+      {
         layer_idx = row;
         project.building.levels[level_idx].set_active_layer(layer_idx);
       }
@@ -413,8 +415,14 @@ Editor::Editor()
   create_tool_button(TOOL_MOVE, ":icons/move.svg", "Move (M)");
   create_tool_button(TOOL_ROTATE, ":icons/rotate.svg", "Rotate (R)");
   create_tool_button(TOOL_ADD_VERTEX, ":icons/vertex.svg", "Add Vertex (V)");
-  create_tool_button(TOOL_ADD_CORRESPONDENCE_POINT, ":icons/correspondence_point.svg", "Add Layer Alignment Point");
-  create_tool_button(TOOL_ADD_FIDUCIAL, ":icons/fiducial.svg", "Add Fiducial");
+  create_tool_button(
+    TOOL_ADD_CORRESPONDENCE_POINT,
+    ":icons/correspondence_point.svg",
+    "Add Layer Alignment Point");
+  create_tool_button(
+    TOOL_ADD_FIDUCIAL,
+    ":icons/fiducial.svg",
+    "Add Level Alignemnt Fiducial");
   create_tool_button(TOOL_ADD_LANE, "", "Add Lane (L)");
   create_tool_button(TOOL_ADD_WALL, ":icons/wall.svg", "Add Wall (W)");
   create_tool_button(
@@ -826,9 +834,8 @@ bool Editor::project_export_correspondence_points()
   dialog.setAcceptMode(QFileDialog::AcceptMode::AcceptSave);
   dialog.setConfirmOverwrite(true);
 
-  if (dialog.exec() != QDialog::Accepted) {
+  if (dialog.exec() != QDialog::Accepted)
     return true;
-  }
 
   QFileInfo file_info(dialog.selectedFiles().first());
   auto result = project.export_correspondence_points(
@@ -959,7 +966,9 @@ void Editor::mouse_event(const MouseType t, QMouseEvent* e)
     case TOOL_ADD_FLOOR:    mouse_add_floor(t, e, p); break;
     case TOOL_ADD_HOLE:     mouse_add_hole(t, e, p); break;
     case TOOL_EDIT_POLYGON: mouse_edit_polygon(t, e, p); break;
-    case TOOL_ADD_CORRESPONDENCE_POINT: mouse_add_correspondence_point(t, e, p); break;
+    case TOOL_ADD_CORRESPONDENCE_POINT:
+      mouse_add_correspondence_point(t, e, p);
+      break;
     case TOOL_ADD_FIDUCIAL: mouse_add_fiducial(t, e, p); break;
     case TOOL_ADD_ROI:      mouse_add_roi(t, e, p); break;
     case TOOL_ADD_HUMAN_LANE: mouse_add_human_lane(t, e, p); break;
@@ -1225,7 +1234,8 @@ void Editor::update_property_editor()
     }
   }
 
-  for (const auto& cp : project.building.levels[level_idx].correspondence_point_sets()[layer_idx])
+  for (const auto& cp :
+    project.building.levels[level_idx].correspondence_point_sets()[layer_idx])
   {
     if (cp.selected())
     {
@@ -1448,12 +1458,17 @@ void Editor::layer_add_button_clicked()
   setWindowModified(true);
 }
 
-void Editor::update_active_layer_checkboxes(int row_idx) {
-  for (size_t ii = 0; ii < project.building.levels[level_idx].layers.size() + 1; ++ii)
+void Editor::update_active_layer_checkboxes(int row_idx)
+{
+  for (size_t ii = 0;
+    ii < project.building.levels[level_idx].layers.size() + 1;
+    ++ii)
   {
-    dynamic_cast<QCheckBox*>(layers_table->cellWidget(ii, 1))->setChecked(false);
+    dynamic_cast<QCheckBox*>(
+      layers_table->cellWidget(ii, 1))->setChecked(false);
   }
-  dynamic_cast<QCheckBox*>(layers_table->cellWidget(row_idx, 1))->setChecked(true);
+  dynamic_cast<QCheckBox*>(
+    layers_table->cellWidget(row_idx, 1))->setChecked(true);
   layer_idx = row_idx;
   project.building.levels[level_idx].set_active_layer(layer_idx);
 }
@@ -1535,7 +1550,8 @@ void Editor::populate_property_editor(const Vertex& vertex)
   property_editor->blockSignals(false);  // re-enable callbacks
 }
 
-void Editor::populate_property_editor(const CorrespondencePoint& correspondence_point)
+void Editor::populate_property_editor(
+  const CorrespondencePoint& correspondence_point)
 {
   property_editor->blockSignals(true);
 
@@ -1822,7 +1838,10 @@ void Editor::mouse_add_vertex(
   }
 }
 
-void Editor::mouse_add_correspondence_point(const MouseType t, QMouseEvent*, const QPointF& p)
+void Editor::mouse_add_correspondence_point(
+  const MouseType t,
+  QMouseEvent*,
+  const QPointF& p)
 {
   if (t == MOUSE_PRESS)
   {
@@ -1885,7 +1904,8 @@ void Editor::mouse_move(
           mouse_vertex_idx);
       // todo: save the QGrahpicsEllipse or group, to avoid full repaints?
     }
-    else if (ni.correspondence_point_idx >= 0 && ni.correspondence_point_dist < 10.0)
+    else if (ni.correspondence_point_idx >= 0 &&
+      ni.correspondence_point_dist < 10.0)
     {
       mouse_correspondence_point_idx = ni.correspondence_point_idx;
       latest_move_correspondence_point = new MoveCorrespondencePointCommand(
@@ -1966,7 +1986,10 @@ void Editor::mouse_move(
   {
     if (!(e->buttons() & Qt::LeftButton))
       return;// we only care about mouse-dragging, not just motion
-    printf("mouse move, vertex_idx = %d, correspondence_point_idx = %d, fiducial_idx = %d\n",
+    printf(
+      "mouse move, vertex_idx = %d, "
+      "correspondence_point_idx = %d, "
+      "fiducial_idx = %d\n",
       mouse_vertex_idx,
       mouse_correspondence_point_idx,
       mouse_fiducial_idx);

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -1365,9 +1365,11 @@ void Editor::layers_table_set_row(
     visible_checkbox, &QAbstractButton::clicked,
     [=](bool box_checked)
     {
-      if (row_idx > 0)
-        project.building.levels[level_idx].layers[row_idx-1].visible =
-        box_checked;
+      if (row_idx == 0) {
+        project.building.levels[level_idx].set_drawing_visible(box_checked);
+      } else if (row_idx > 0) {
+        project.building.levels[level_idx].layers[row_idx-1].visible = box_checked;
+      }
       create_scene();
     });
   connect(

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -100,6 +100,7 @@ Editor::Editor()
     [=](int row, int /*col*/) {
       if (row < static_cast<int>(project.building.levels[level_idx].layers.size())) {
         layer_idx = row;
+        project.building.levels[level_idx].set_active_layer(layer_idx);
       }
     });
 
@@ -1194,7 +1195,7 @@ void Editor::update_property_editor()
     }
   }
 
-  for (const auto& cp : project.building.levels[level_idx].layers[layer_idx].correspondence_points)
+  for (const auto& cp : project.building.levels[level_idx].correspondence_point_sets()[layer_idx])
   {
     if (cp.selected())
     {
@@ -1357,9 +1358,8 @@ void Editor::layers_table_set_row(
     active_checkbox, &QAbstractButton::clicked,
     [=](bool box_checked)
     {
-      if (box_checked) {
-        update_active_layer_checkboxes(row_idx);
-      }
+      update_active_layer_checkboxes(row_idx);
+      create_scene();
     });
   connect(
     visible_checkbox, &QAbstractButton::clicked,
@@ -1424,6 +1424,7 @@ void Editor::update_active_layer_checkboxes(int row_idx) {
   }
   dynamic_cast<QCheckBox*>(layers_table->cellWidget(row_idx, 1))->setChecked(true);
   layer_idx = row_idx;
+  project.building.levels[level_idx].set_active_layer(layer_idx);
 }
 
 void Editor::populate_property_editor(const Edge& edge)
@@ -1962,7 +1963,7 @@ void Editor::mouse_move(
     else if (mouse_correspondence_point_idx >= 0)
     {
       CorrespondencePoint& cp =
-        project.building.levels[level_idx].layers[layer_idx].correspondence_points[mouse_correspondence_point_idx];
+        project.building.levels[level_idx].correspondence_point_sets()[layer_idx][mouse_correspondence_point_idx];
       cp.set_x(p.x());
       cp.set_y(p.y());
       latest_move_correspondence_point->set_final_destination(p.x(), p.y());

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -288,7 +288,7 @@ Editor::Editor()
     QKeySequence(Qt::CTRL + Qt::Key_S));
 
   project_menu->addAction(
-    "&Export correspondence points for level",
+    "&Export layer alignment points for level",
     this,
     &Editor::project_export_correspondence_points,
     QKeySequence(Qt::CTRL + Qt::Key_E));
@@ -409,7 +409,7 @@ Editor::Editor()
   create_tool_button(TOOL_MOVE, ":icons/move.svg", "Move (M)");
   create_tool_button(TOOL_ROTATE, ":icons/rotate.svg", "Rotate (R)");
   create_tool_button(TOOL_ADD_VERTEX, ":icons/vertex.svg", "Add Vertex (V)");
-  create_tool_button(TOOL_ADD_CORRESPONDENCE_POINT, ":icons/correspondence_point.svg", "Add Correspondence Point");
+  create_tool_button(TOOL_ADD_CORRESPONDENCE_POINT, ":icons/correspondence_point.svg", "Add Layer Alignment Point");
   create_tool_button(TOOL_ADD_FIDUCIAL, ":icons/fiducial.svg", "Add Fiducial");
   create_tool_button(TOOL_ADD_LANE, "", "Add Lane (L)");
   create_tool_button(TOOL_ADD_WALL, ":icons/wall.svg", "Add Wall (W)");
@@ -816,7 +816,7 @@ bool Editor::project_save()
 
 bool Editor::project_export_correspondence_points()
 {
-  QFileDialog dialog(this, "Export correspondence points for level");
+  QFileDialog dialog(this, "Export layer alignment points for level");
   dialog.setNameFilter("*.yaml");
   dialog.setDefaultSuffix(".yaml");
   dialog.setAcceptMode(QFileDialog::AcceptMode::AcceptSave);
@@ -1094,7 +1094,7 @@ const QString Editor::tool_id_to_string(const int id)
     case TOOL_ADD_HOLE: return "add hole";
     case TOOL_EDIT_POLYGON: return "&edit polygon";
     case TOOL_ADD_HUMAN_LANE: return "add human lane";
-    case TOOL_ADD_CORRESPONDENCE_POINT: return "add &correspondence point";
+    case TOOL_ADD_CORRESPONDENCE_POINT: return "add layer &alignment point";
     default: return "unknown tool ID";
   }
 }

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -99,7 +99,8 @@ Editor::Editor()
   layers_table->setHorizontalHeaderLabels(header_labels);
   connect(
     layers_table, &QTableWidget::cellClicked,
-    [=](int row, int /*col*/) {
+    [=](int row, int /*col*/)
+    {
       if (row < static_cast<int>(
         project.building.levels[level_idx].layers.size()))
       {
@@ -1396,7 +1397,7 @@ void Editor::layers_table_set_row(
 
   connect(
     active_checkbox, &QAbstractButton::clicked,
-    [=](bool box_checked)
+    [=](bool)
     {
       update_active_layer_checkboxes(row_idx);
       create_scene();
@@ -1405,10 +1406,14 @@ void Editor::layers_table_set_row(
     visible_checkbox, &QAbstractButton::clicked,
     [=](bool box_checked)
     {
-      if (row_idx == 0) {
-        project.building.levels[level_idx].set_drawing_visible(box_checked);
-      } else if (row_idx > 0) {
-        project.building.levels[level_idx].layers[row_idx-1].visible = box_checked;
+      auto& level = project.building.levels[level_idx];
+      if (row_idx == 0)
+      {
+        level.set_drawing_visible(box_checked);
+      }
+      else if (row_idx > 0)
+      {
+        level.layers[row_idx-1].visible = box_checked;
       }
       create_scene();
     });
@@ -2017,7 +2022,8 @@ void Editor::mouse_move(
     else if (mouse_correspondence_point_idx >= 0)
     {
       CorrespondencePoint& cp =
-        project.building.levels[level_idx].correspondence_point_sets()[layer_idx][mouse_correspondence_point_idx];
+        project.building.levels[level_idx].correspondence_point_sets()
+        [layer_idx][mouse_correspondence_point_idx];
       cp.set_x(p.x());
       cp.set_y(p.y());
       latest_move_correspondence_point->set_final_destination(p.x(), p.y());

--- a/traffic_editor/gui/editor.h
+++ b/traffic_editor/gui/editor.h
@@ -33,6 +33,7 @@
 
 #include "project.h"
 #include "actions/add_edge.h"
+#include "actions/move_correspondence_point.hpp"
 #include "actions/move_fiducial.h"
 #include "actions/move_model.h"
 #include "actions/move_vertex.h"
@@ -129,6 +130,7 @@ private:
     TOOL_ADD_FLOOR,
     TOOL_EDIT_POLYGON,
     TOOL_ADD_ZONE,
+    TOOL_ADD_CORRESPONDENCE_POINT,
     TOOL_ADD_FIDUCIAL,
     TOOL_ADD_ROI,
     TOOL_ADD_HOLE,
@@ -178,6 +180,7 @@ private:
 
   Project project;
   int level_idx = 0;  // level that we are currently editing
+  int layer_idx = 0;  // currently selected layer
   int clicked_idx = -1;  // point most recently clicked
   int prev_clicked_idx = -1; // Previously clicked ID.
   //int polygon_idx = -1;  // currently selected polygon
@@ -209,6 +212,7 @@ private:
     const bool checked);
   void layer_edit_button_clicked(const std::string& label);
   void layer_add_button_clicked();
+  void update_active_layer_checkboxes(int row_idx);
 
   BuildingLevelTable* level_table;
   LiftTable* lift_table;
@@ -222,6 +226,7 @@ private:
   void populate_property_editor(const Edge& edge);
   void populate_property_editor(const Model& model);
   void populate_property_editor(const Vertex& vertex);
+  void populate_property_editor(const CorrespondencePoint& correspondence_point);
   void populate_property_editor(const Fiducial& fiducial);
   void populate_property_editor(const Polygon& polygon);
 
@@ -286,6 +291,7 @@ private:
 
   int mouse_model_idx = -1;
   int mouse_vertex_idx = -1;
+  int mouse_correspondence_point_idx = -1;
   int mouse_fiducial_idx = -1;
   std::vector<int> mouse_motion_polygon_vertices;
   //int mouse_motion_polygon_vertex_idx = -1;
@@ -330,6 +336,7 @@ private:
   void mouse_rotate(const MouseType t, QMouseEvent* e, const QPointF& p);
 
   void mouse_add_vertex(const MouseType t, QMouseEvent* e, const QPointF& p);
+  void mouse_add_correspondence_point(const MouseType t, QMouseEvent* e, const QPointF& p);
   void mouse_add_fiducial(const MouseType t, QMouseEvent* e, const QPointF& p);
   void mouse_add_lane(const MouseType t, QMouseEvent* e, const QPointF& p);
   void mouse_add_wall(const MouseType t, QMouseEvent* e, const QPointF& p);
@@ -348,6 +355,7 @@ private:
 
   // For undo related support
   AddEdgeCommand* latest_add_edge;
+  MoveCorrespondencePointCommand* latest_move_correspondence_point;
   MoveFiducialCommand* latest_move_fiducial;
   MoveModelCommand* latest_move_model;
   MoveVertexCommand* latest_move_vertex;

--- a/traffic_editor/gui/editor.h
+++ b/traffic_editor/gui/editor.h
@@ -223,7 +223,8 @@ private:
   void populate_property_editor(const Edge& edge);
   void populate_property_editor(const Model& model);
   void populate_property_editor(const Vertex& vertex);
-  void populate_property_editor(const CorrespondencePoint& correspondence_point);
+  void populate_property_editor(
+    const CorrespondencePoint& correspondence_point);
   void populate_property_editor(const Fiducial& fiducial);
   void populate_property_editor(const Polygon& polygon);
 
@@ -333,7 +334,10 @@ private:
   void mouse_rotate(const MouseType t, QMouseEvent* e, const QPointF& p);
 
   void mouse_add_vertex(const MouseType t, QMouseEvent* e, const QPointF& p);
-  void mouse_add_correspondence_point(const MouseType t, QMouseEvent* e, const QPointF& p);
+  void mouse_add_correspondence_point(
+    const MouseType t,
+    QMouseEvent* e,
+    const QPointF& p);
   void mouse_add_fiducial(const MouseType t, QMouseEvent* e, const QPointF& p);
   void mouse_add_lane(const MouseType t, QMouseEvent* e, const QPointF& p);
   void mouse_add_wall(const MouseType t, QMouseEvent* e, const QPointF& p);

--- a/traffic_editor/gui/editor.h
+++ b/traffic_editor/gui/editor.h
@@ -146,6 +146,7 @@ private:
   void project_new();
   void project_open();
   bool project_save();
+  bool project_export_correspondence_points();
 
   bool maybe_save();
   void edit_undo();

--- a/traffic_editor/gui/layer.cpp
+++ b/traffic_editor/gui/layer.cpp
@@ -17,6 +17,7 @@
 
 #include <QImageReader>
 #include "traffic_editor/layer.h"
+#include "traffic_editor/correspondence_point.hpp"
 using std::string;
 using std::vector;
 
@@ -40,6 +41,16 @@ bool Layer::from_yaml(const std::string& _name, const YAML::Node& y)
   rotation = y["rotation"].as<double>();
   if (y["visible"])
     visible = y["visible"].as<bool>();
+  if (y["correspondence_points"] && y["correspondence_points"].IsSequence())
+  {
+    const YAML::Node& points = y["correspondence_points"];
+    for (YAML::const_iterator it = points.begin(); it != points.end(); ++it)
+    {
+      CorrespondencePoint cp;
+      cp.from_yaml(*it);
+      correspondence_points.push_back(cp);
+    }
+  }
 
   // now try to load the image
   QImageReader image_reader(QString::fromStdString(filename));
@@ -69,5 +80,8 @@ YAML::Node Layer::to_yaml() const
   y["translation_y"] = translation_y;
   y["rotation"] = rotation;
   y["visible"] = visible;
+  for (const auto& cp : correspondence_points)
+    y["correspondence_points"].push_back(cp.to_yaml());
+
   return y;
 }

--- a/traffic_editor/gui/layer.cpp
+++ b/traffic_editor/gui/layer.cpp
@@ -41,16 +41,6 @@ bool Layer::from_yaml(const std::string& _name, const YAML::Node& y)
   rotation = y["rotation"].as<double>();
   if (y["visible"])
     visible = y["visible"].as<bool>();
-  if (y["correspondence_points"] && y["correspondence_points"].IsSequence())
-  {
-    const YAML::Node& points = y["correspondence_points"];
-    for (YAML::const_iterator it = points.begin(); it != points.end(); ++it)
-    {
-      CorrespondencePoint cp;
-      cp.from_yaml(*it);
-      correspondence_points.push_back(cp);
-    }
-  }
 
   // now try to load the image
   QImageReader image_reader(QString::fromStdString(filename));
@@ -80,8 +70,6 @@ YAML::Node Layer::to_yaml() const
   y["translation_y"] = translation_y;
   y["rotation"] = rotation;
   y["visible"] = visible;
-  for (const auto& cp : correspondence_points)
-    y["correspondence_points"].push_back(cp.to_yaml());
 
   return y;
 }

--- a/traffic_editor/gui/project.cpp
+++ b/traffic_editor/gui/project.cpp
@@ -171,6 +171,11 @@ bool Project::load(const std::string& _filename)
   return load_yaml_file(_filename);
 }
 
+bool Project::export_correspondence_points(int level_index, const std::string& dest_filename) const
+{
+  return building.export_level_correspondence_points(level_index, dest_filename);
+}
+
 void Project::add_scenario_vertex(
   const int level_idx,
   const double x,

--- a/traffic_editor/gui/project.cpp
+++ b/traffic_editor/gui/project.cpp
@@ -284,10 +284,10 @@ Project::NearestItem Project::nearest_items(
 
     for (
       size_t ii = 0;
-      ii < building_level.layers[layer_index].correspondence_points.size();
+      ii < building_level.correspondence_point_sets()[layer_index].size();
       ++ii)
     {
-      const CorrespondencePoint& cp = building_level.layers[layer_index].correspondence_points[ii];
+      const CorrespondencePoint& cp = building_level.correspondence_point_sets()[layer_index][ii];
       const double dx = x - cp.x();
       const double dy = y - cp.y();
       const double dist = std::sqrt(dx*dx + dy*dy);

--- a/traffic_editor/gui/project.cpp
+++ b/traffic_editor/gui/project.cpp
@@ -171,9 +171,13 @@ bool Project::load(const std::string& _filename)
   return load_yaml_file(_filename);
 }
 
-bool Project::export_correspondence_points(int level_index, const std::string& dest_filename) const
+bool Project::export_correspondence_points(
+  int level_index,
+  const std::string& dest_filename) const
 {
-  return building.export_level_correspondence_points(level_index, dest_filename);
+  return building.export_level_correspondence_points(
+    level_index,
+    dest_filename);
 }
 
 void Project::add_scenario_vertex(
@@ -292,7 +296,8 @@ Project::NearestItem Project::nearest_items(
       ii < building_level.correspondence_point_sets()[layer_index].size();
       ++ii)
     {
-      const CorrespondencePoint& cp = building_level.correspondence_point_sets()[layer_index][ii];
+      const CorrespondencePoint& cp =
+        building_level.correspondence_point_sets()[layer_index][ii];
       const double dx = x - cp.x();
       const double dy = y - cp.y();
       const double dist = std::sqrt(dx*dx + dy*dy);

--- a/traffic_editor/gui/project.cpp
+++ b/traffic_editor/gui/project.cpp
@@ -257,6 +257,7 @@ void Project::get_selected_items(
 Project::NearestItem Project::nearest_items(
   EditorModeId mode,
   const int level_index,
+  const int layer_index,
   const double x,
   const double y)
 {
@@ -278,6 +279,35 @@ Project::NearestItem Project::nearest_items(
       {
         ni.vertex_dist = dist;
         ni.vertex_idx = i;
+      }
+    }
+
+    for (
+      size_t ii = 0;
+      ii < building_level.layers[layer_index].correspondence_points.size();
+      ++ii)
+    {
+      const CorrespondencePoint& cp = building_level.layers[layer_index].correspondence_points[ii];
+      const double dx = x - cp.x();
+      const double dy = y - cp.y();
+      const double dist = std::sqrt(dx*dx + dy*dy);
+      if (dist < ni.correspondence_point_dist)
+      {
+        ni.correspondence_point_dist = dist;
+        ni.correspondence_point_idx = ii;
+      }
+    }
+
+    for (size_t i = 0; i < building_level.fiducials.size(); i++)
+    {
+      const Fiducial& f = building_level.fiducials[i];
+      const double dx = x - f.x;
+      const double dy = y - f.y;
+      const double dist = std::sqrt(dx*dx + dy*dy);
+      if (dist < ni.fiducial_dist)
+      {
+        ni.fiducial_dist = dist;
+        ni.fiducial_idx = i;
       }
     }
 
@@ -359,12 +389,13 @@ ScenarioLevel* Project::scenario_level(const int building_level_idx)
 void Project::mouse_select_press(
   const EditorModeId mode,
   const int level_idx,
+  const int layer_idx,
   const double x,
   const double y,
   QGraphicsItem* graphics_item)
 {
   clear_selection(level_idx);
-  const NearestItem ni = nearest_items(mode, level_idx, x, y);
+  const NearestItem ni = nearest_items(mode, level_idx, layer_idx, x, y);
 
   const double vertex_dist_thresh =
     building.levels[level_idx].vertex_radius /

--- a/traffic_editor/gui/project.h
+++ b/traffic_editor/gui/project.h
@@ -85,6 +85,9 @@ public:
     double vertex_dist = 1e100;
     int vertex_idx = -1;
 
+    double correspondence_point_dist = 1e100;
+    int correspondence_point_idx = -1;
+
     double fiducial_dist = 1e100;
     int fiducial_idx = -1;
   };
@@ -92,6 +95,7 @@ public:
   NearestItem nearest_items(
     EditorModeId mode,
     const int level_index,
+    const int layer_index,
     const double x,
     const double y);
 
@@ -106,6 +110,7 @@ public:
   void mouse_select_press(
     const EditorModeId mode,
     const int level_idx,
+    const int layer_index,
     const double x,
     const double y,
     QGraphicsItem* graphics_item);

--- a/traffic_editor/gui/project.h
+++ b/traffic_editor/gui/project.h
@@ -53,7 +53,9 @@ public:
 
   bool save();
   bool load(const std::string& _filename);
-  bool export_correspondence_points(int level_index, const std::string& dest_filename) const;
+  bool export_correspondence_points(
+    int level_index,
+    const std::string& dest_filename) const;
 
   void clear();
 

--- a/traffic_editor/gui/project.h
+++ b/traffic_editor/gui/project.h
@@ -53,6 +53,7 @@ public:
 
   bool save();
   bool load(const std::string& _filename);
+  bool export_correspondence_points(int level_index, const std::string& dest_filename) const;
 
   void clear();
 

--- a/traffic_editor/gui/scenario_level.h
+++ b/traffic_editor/gui/scenario_level.h
@@ -34,6 +34,8 @@ public:
   ScenarioLevel();
   ~ScenarioLevel();
 
+  void layer_added() {}
+
   bool from_yaml(const std::string& _name, const YAML::Node& yaml_node);
   YAML::Node to_yaml() const;
 

--- a/traffic_editor/include/traffic_editor/building.h
+++ b/traffic_editor/include/traffic_editor/building.h
@@ -54,7 +54,9 @@ public:
   bool save_yaml_file();
   void clear();  // clear all internal data structures
 
-  bool export_level_correspondence_points(int level_index, const std::string& dest_filename) const;
+  bool export_level_correspondence_points(
+    int level_index,
+    const std::string& dest_filename) const;
 
   void add_level(const BuildingLevel& level);
 

--- a/traffic_editor/include/traffic_editor/building.h
+++ b/traffic_editor/include/traffic_editor/building.h
@@ -58,6 +58,7 @@ public:
 
   void add_vertex(int level_index, double x, double y);
   QUuid add_fiducial(int level_index, double x, double y);
+  QUuid add_correspondence_point(int level, int layer, double x, double y);
 
   int find_nearest_vertex_index(
     int level_index, double x, double y, double& distance);
@@ -71,12 +72,16 @@ public:
     double vertex_dist = 1e100;
     int vertex_idx = -1;
 
+    double correspondence_point_dist = 1e100;
+    int correspondence_point_idx = -1;
+
     double fiducial_dist = 1e100;
     int fiducial_idx = -1;
   };
 
   NearestItem nearest_items(
     const int level_index,
+    const int layer_index,
     const double x,
     const double y);
 

--- a/traffic_editor/include/traffic_editor/building.h
+++ b/traffic_editor/include/traffic_editor/building.h
@@ -54,6 +54,8 @@ public:
   bool save_yaml_file();
   void clear();  // clear all internal data structures
 
+  bool export_level_correspondence_points(int level_index, const std::string& dest_filename) const;
+
   void add_level(const BuildingLevel& level);
 
   void add_vertex(int level_index, double x, double y);

--- a/traffic_editor/include/traffic_editor/building_level.h
+++ b/traffic_editor/include/traffic_editor/building_level.h
@@ -94,11 +94,14 @@ public:
 
   void set_drawing_visible(bool value) { drawing_visible_ = value; }
 
-  const std::vector<std::vector<CorrespondencePoint>>& correspondence_point_sets() const {
+  const std::vector<std::vector<CorrespondencePoint>>&
+  correspondence_point_sets() const
+  {
     return correspondence_point_sets_;
   }
 
-  std::vector<std::vector<CorrespondencePoint>>& correspondence_point_sets() {
+  std::vector<std::vector<CorrespondencePoint>>& correspondence_point_sets()
+  {
     return correspondence_point_sets_;
   }
 

--- a/traffic_editor/include/traffic_editor/building_level.h
+++ b/traffic_editor/include/traffic_editor/building_level.h
@@ -102,8 +102,10 @@ public:
     return correspondence_point_sets_;
   }
 
+  void layer_added();
   void set_active_layer(int active_layer) { active_layer_ = active_layer; }
   QUuid add_correspondence_point(int layer, double x, double y);
+  bool export_correspondence_points(const std::string& filename) const;
 
 private:
   bool drawing_visible_ = true;

--- a/traffic_editor/include/traffic_editor/building_level.h
+++ b/traffic_editor/include/traffic_editor/building_level.h
@@ -23,6 +23,7 @@
 #include <yaml-cpp/yaml.h>
 #include <string>
 
+#include "traffic_editor/correspondence_point.hpp"
 #include "traffic_editor/edge.h"
 #include "traffic_editor/editor_model.h"
 #include "traffic_editor/fiducial.h"
@@ -93,8 +94,22 @@ public:
 
   void set_drawing_visible(bool value) { drawing_visible_ = value; }
 
+  const std::vector<std::vector<CorrespondencePoint>>& correspondence_point_sets() const {
+    return correspondence_point_sets_;
+  }
+
+  std::vector<std::vector<CorrespondencePoint>>& correspondence_point_sets() {
+    return correspondence_point_sets_;
+  }
+
+  void set_active_layer(int active_layer) { active_layer_ = active_layer; }
+  QUuid add_correspondence_point(int layer, double x, double y);
+
 private:
   bool drawing_visible_ = true;
+  std::vector<std::vector<CorrespondencePoint>> correspondence_point_sets_;
+  std::vector<int> next_cp_ids;
+  int active_layer_ = 0;
 
   void draw_lane(
     QGraphicsScene* scene,

--- a/traffic_editor/include/traffic_editor/building_level.h
+++ b/traffic_editor/include/traffic_editor/building_level.h
@@ -91,7 +91,11 @@ public:
 
   bool load_drawing();
 
+  void set_drawing_visible(bool value) { drawing_visible_ = value; }
+
 private:
+  bool drawing_visible_ = true;
+
   void draw_lane(
     QGraphicsScene* scene,
     const Edge& edge,

--- a/traffic_editor/include/traffic_editor/correspondence_point.hpp
+++ b/traffic_editor/include/traffic_editor/correspondence_point.hpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef TRAFFIC_EDITOR__CORRESPONDENCE_POINT_HPP
+#define TRAFFIC_EDITOR__CORRESPONDENCE_POINT_HPP
+
+#include <yaml-cpp/yaml.h>
+#include <quuid.h>
+
+class QGraphicsScene;
+
+class CorrespondencePoint
+{
+public:
+  CorrespondencePoint();
+  CorrespondencePoint(double x, double y);
+
+  double x() const { return x_; }
+  void set_x(double x) { x_ = x; }
+  double y() const { return y_; }
+  void set_y(double y) { y_ = y; }
+  uint16_t id() const { return id_; }
+  QUuid const& uuid() const { return uuid_; }
+  bool selected() const { return selected_; }
+
+  void from_yaml(const YAML::Node& data);
+  YAML::Node to_yaml() const;
+
+  void draw(QGraphicsScene*, double meters_per_pixel) const;
+
+private:
+  double x_ = 0.0;
+  double y_ = 0.0;
+  uint16_t id_ = 0;
+  QUuid uuid_;
+  bool selected_ = false;
+
+  static uint16_t next_id_;
+};
+
+#endif  // TRAFFIC_EDITOR__CORRESPONDENCE_POINT_HPP

--- a/traffic_editor/include/traffic_editor/correspondence_point.hpp
+++ b/traffic_editor/include/traffic_editor/correspondence_point.hpp
@@ -27,7 +27,7 @@ class CorrespondencePoint
 {
 public:
   CorrespondencePoint();
-  CorrespondencePoint(double x, double y);
+  CorrespondencePoint(double x, double y, int id);
 
   double x() const { return x_; }
   void set_x(double x) { x_ = x; }

--- a/traffic_editor/include/traffic_editor/layer.h
+++ b/traffic_editor/include/traffic_editor/layer.h
@@ -18,10 +18,12 @@
 #ifndef LAYER_H
 #define LAYER_H
 
+#include "traffic_editor/correspondence_point.hpp"
+
 #include <string>
+#include <vector>
 
 #include <QPixmap>
-
 #include <yaml-cpp/yaml.h>
 
 
@@ -39,6 +41,7 @@ public:
   double translation_x = 0.0;
   double translation_y = 0.0;
   double rotation = 0.0;
+  std::vector<CorrespondencePoint> correspondence_points;
 
   QPixmap pixmap;
 

--- a/traffic_editor/include/traffic_editor/layer.h
+++ b/traffic_editor/include/traffic_editor/layer.h
@@ -25,6 +25,9 @@
 #include <yaml-cpp/yaml.h>
 
 
+class QGraphicsPixmapItem;
+
+
 class Layer
 {
 public:
@@ -41,6 +44,7 @@ public:
   double rotation = 0.0;
 
   QPixmap pixmap;
+  QGraphicsPixmapItem* scene_item = nullptr;  // Borrowed pointer, not owned, don't delete
 
   bool from_yaml(const std::string& name, const YAML::Node& data);
   YAML::Node to_yaml() const;

--- a/traffic_editor/include/traffic_editor/layer.h
+++ b/traffic_editor/include/traffic_editor/layer.h
@@ -18,8 +18,6 @@
 #ifndef LAYER_H
 #define LAYER_H
 
-#include "traffic_editor/correspondence_point.hpp"
-
 #include <string>
 #include <vector>
 
@@ -41,7 +39,6 @@ public:
   double translation_x = 0.0;
   double translation_y = 0.0;
   double rotation = 0.0;
-  std::vector<CorrespondencePoint> correspondence_points;
 
   QPixmap pixmap;
 

--- a/traffic_editor/include/traffic_editor/level.h
+++ b/traffic_editor/include/traffic_editor/level.h
@@ -46,6 +46,7 @@ public:
   std::vector<Polygon> polygons;
 
   std::vector<Layer> layers;
+  virtual void layer_added() = 0;
 
   // temporary, just for debugging polygon edge projection...
   double polygon_edge_proj_x = 0.0;

--- a/traffic_editor/resources/icons/correspondence_point.svg
+++ b/traffic_editor/resources/icons/correspondence_point.svg
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="33.396389mm"
+   height="32.652649mm"
+   viewBox="0 0 33.396389 32.652649"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="correspondence_point.svg">
+  <defs
+     id="defs2">
+    <marker
+       style="overflow:visible"
+       id="Arrow2Send"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow2Send"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.3,0,0,-0.3,0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path922" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Send"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Send"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path904" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Mend"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Mend"
+       inkscape:isstock="true">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path898" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.979899"
+     inkscape:cx="-72.166016"
+     inkscape:cy="-164.68982"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="3840"
+     inkscape:window-height="2128"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-99.245236,-121.60212)">
+    <g
+       id="g857"
+       style="fill:none;stroke:#ae0000;stroke-opacity:1">
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#ae0000;stroke-width:1.05833;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 99.619412,143.11941 10.761178,10.76118"
+         id="path833" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#ae0000;stroke-width:1.05833;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 110.38059,143.11941 99.619412,153.88059"
+         id="path833-3" />
+    </g>
+    <g
+       id="g857-6"
+       transform="translate(21.88686,-21.143117)"
+       style="fill:none;stroke:#ae0000;stroke-opacity:1">
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#ae0000;stroke-width:1.05833;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 99.619412,143.11941 10.761178,10.76118"
+         id="path833-7" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#ae0000;stroke-width:1.05833;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 110.38059,143.11941 99.619412,153.88059"
+         id="path833-3-5" />
+    </g>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.41111;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Send)"
+       d="m 107.65419,149.10845 c 6.13086,-2.62909 14.70469,-6.38955 18.43294,-17.43239"
+       id="path887"
+       sodipodi:nodetypes="cc" />
+  </g>
+</svg>

--- a/traffic_editor/resources/resource.qrc
+++ b/traffic_editor/resources/resource.qrc
@@ -5,6 +5,7 @@
   <file>icons/move.svg</file>
   <file>icons/rotate.svg</file>
   <file>icons/select.svg</file>
+  <file>icons/correspondence_point.svg</file>
   <file>icons/fiducial.svg</file>
   <file>icons/roi.svg</file>
   <file>icons/floor.svg</file>


### PR DESCRIPTION
This adds the required UI to be able to specify correspondence points for each layer of a level, then save those correspondence points to a separate YAML file that can be used with the map transformer library.