### PR TITLE
hotfix for #295

### DIFF
--- a/traffic_editor/gui/building_level.cpp
+++ b/traffic_editor/gui/building_level.cpp
@@ -1027,8 +1027,11 @@ void BuildingLevel::draw(
       scene,
       vertex_radius / drawing_meters_per_pixel);
 
-  for (const auto& cp : correspondence_point_sets_[active_layer_])
-    cp.draw(scene, drawing_meters_per_pixel);
+  if (active_layer_ < static_cast<int>(correspondence_point_sets_.size()))
+  {
+    for (const auto& cp : correspondence_point_sets_[active_layer_])
+      cp.draw(scene, drawing_meters_per_pixel);
+  }
 
   for (const auto& f : fiducials)
     f.draw(scene, drawing_meters_per_pixel);

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -1235,13 +1235,17 @@ void Editor::update_property_editor()
     }
   }
 
-  for (const auto& cp :
-    project.building.levels[level_idx].correspondence_point_sets()[layer_idx])
+  if (level_idx > static_cast<int>(
+    project.building.levels[level_idx].correspondence_point_sets().size()))
   {
-    if (cp.selected())
+    for (const auto& cp :
+      project.building.levels[level_idx].correspondence_point_sets()[layer_idx])
     {
-      populate_property_editor(cp);
-      return;  // stop after finding the first one
+      if (cp.selected())
+      {
+        populate_property_editor(cp);
+        return;  // stop after finding the first one
+      }
     }
   }
 

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -1236,7 +1236,7 @@ void Editor::update_property_editor()
   }
 
   if (level_idx > static_cast<int>(
-    project.building.levels[level_idx].correspondence_point_sets().size()))
+      project.building.levels[level_idx].correspondence_point_sets().size()))
   {
     for (const auto& cp :
       project.building.levels[level_idx].correspondence_point_sets()[layer_idx])


### PR DESCRIPTION
Check bounds of correspondence point vector. For newly-created levels, this can be empty and lead to :boom:   Fixes #295 

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>