### PR TITLE
correctly exit add-edge mode, fix #297

### DIFF
--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -1028,9 +1028,9 @@ void Editor::keyPressEvent(QKeyEvent* e)
       break;
     case Qt::Key_S:
     case Qt::Key_Escape:
-      tool_button_group->button(TOOL_SELECT)->click();
       project.clear_selection(level_idx);
       clear_current_tool_buffer();
+      tool_button_group->button(TOOL_SELECT)->click();
       update_property_editor();
       create_scene();
       break;

--- a/traffic_editor/gui/project.cpp
+++ b/traffic_editor/gui/project.cpp
@@ -291,20 +291,20 @@ Project::NearestItem Project::nearest_items(
       }
     }
 
-    for (
-      size_t ii = 0;
-      ii < building_level.correspondence_point_sets()[layer_index].size();
-      ++ii)
+    const auto& cp_sets = building_level.correspondence_point_sets();
+    if (layer_index < static_cast<int>(cp_sets.size()))
     {
-      const CorrespondencePoint& cp =
-        building_level.correspondence_point_sets()[layer_index][ii];
-      const double dx = x - cp.x();
-      const double dy = y - cp.y();
-      const double dist = std::sqrt(dx*dx + dy*dy);
-      if (dist < ni.correspondence_point_dist)
+      for (size_t i = 0; i < cp_sets[layer_index].size(); i++)
       {
-        ni.correspondence_point_dist = dist;
-        ni.correspondence_point_idx = ii;
+        const CorrespondencePoint& cp = cp_sets[layer_index][i];
+        const double dx = x - cp.x();
+        const double dy = y - cp.y();
+        const double dist = std::sqrt(dx*dx + dy*dy);
+        if (dist < ni.correspondence_point_dist)
+        {
+          ni.correspondence_point_dist = dist;
+          ni.correspondence_point_idx = i;
+        }
       }
     }
 


### PR DESCRIPTION
The add-edge tools were correctly exiting via right-click, but not via `[ESCAPE]` key. This PR just switches the order the underlying functions were being called to fix it. It also fixes an unrelated crash that resulted from exiting the tool correctly.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>