### PR TITLE
allow parsing failures to not crash building_crowdsim

### DIFF
--- a/building_map_tools/building_crowdsim/building_yaml_parse.py
+++ b/building_map_tools/building_crowdsim/building_yaml_parse.py
@@ -58,6 +58,8 @@ class BuildingYamlParse:
         self.levels_with_human_lanes = {}
         self.levels_name = []
         for level_name, level_yaml in self.yaml_node['levels'].items():
+            if 'human_lanes' not in level_yaml:
+                raise ValueError(f'expected human_lanes in level')
             self.levels_with_human_lanes[level_name] = LevelWithHumanLanes(
                 level_yaml, level_name)
             self.levels_name.append(level_name)

--- a/building_map_tools/building_crowdsim/config/configfile_generator.py
+++ b/building_map_tools/building_crowdsim/config/configfile_generator.py
@@ -132,7 +132,12 @@ def configfile_main(map_file, output_dir, world_file_to_be_inserted):
     if not os.path.exists(world_file_to_be_inserted):
         world_file_to_be_inserted = ""
 
-    yaml_parse = BuildingYamlParse(map_file)
+    try:
+        yaml_parse = BuildingYamlParse(map_file)
+    except ValueError as e:
+        print('crowdsim unable to parse, not attempting to proceed')
+        return
+
     configfile_generator = ConfigFileGenerator(yaml_parse)
     configfile_generator.generate_behavior_file(output_dir)
     configfile_generator.generate_scene_file(output_dir)

--- a/building_map_tools/building_crowdsim/navmesh/navmesh_generator.py
+++ b/building_map_tools/building_crowdsim/navmesh/navmesh_generator.py
@@ -89,7 +89,11 @@ def navmesh_main(map_file, output_dir):
         os.makedirs(output_dir)
 
     # parse the yaml file
-    yaml_parse = BuildingYamlParse(map_file)
+    try:
+        yaml_parse = BuildingYamlParse(map_file)
+    except ValueError as e:
+        print('crowdsim unable to parse, not attempting to proceed')
+        return
 
     for level_name in yaml_parse.levels_name:
         # navmesh output


### PR DESCRIPTION
Previously the `building_crowdsim` generator would throw Python exceptions (crash) if it didn't find the YAML keys it expected in the building files. This was not convenient if using a `cmake GLOB` to collect all the building files and generate their maps, since it would lead to broken builds if any of the buildings didn't have any human data. This PR tweaks `building_crowdsim` a bit so that it doesn't crash in this case and just exits cleanly without doing anything.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>