### PR TITLE
Add minimal CI test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: ci
 on: [push, pull_request]
 jobs:
   ci:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container:
-      image: docker://ros:eloquent-ros-base-bionic
+      image: docker://ros:foxy-ros-base-focal
     
     steps:
     - name: osrf-repo
@@ -12,7 +12,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y wget
-        echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable bionic main" > /etc/apt/sources.list.d/gazebo-stable.list
+        echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable focal main" > /etc/apt/sources.list.d/gazebo-stable.list
         wget https://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
         sudo apt-get update
         sudo apt-get install -y libignition-plugin-dev libignition-common3-dev
@@ -36,21 +36,20 @@ jobs:
       shell: bash
       run: |
         cd ws
-        source /opt/ros/eloquent/setup.bash
+        source /opt/ros/foxy/setup.bash
         colcon build --packages-select traffic_editor --cmake-args -DNO_DOWNLOAD_MODELS=True
 
     - name: test
       shell: bash
       run: |
         cd ws
-        source /opt/ros/eloquent/setup.bash
-        colcon test --packages-select traffic_editor --cmake-args -DNO_DOWNLOAD_MODELS=True
-
+        source /opt/ros/foxy/setup.bash
+        colcon test --packages-select traffic_editor
     - name: test-results
       shell: bash
       run: |
         cd ws
-        source /opt/ros/eloquent/setup.bash
+        source /opt/ros/foxy/setup.bash
         colcon test-results --verbose
 
   ci_without_plugin_support:
@@ -94,7 +93,7 @@ jobs:
       run: |
         cd ws
         source /opt/ros/eloquent/setup.bash
-        colcon test --packages-select traffic_editor --cmake-args -DNO_DOWNLOAD_MODELS=True
+        colcon test --packages-select traffic_editor
 
     - name: test-results
       shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
       run: |
         cd ws
         source /opt/ros/foxy/setup.bash
-        colcon test-results --verbose
+        colcon test-result --verbose
 
   ci_without_plugin_support:
     runs-on: ubuntu-18.04
@@ -100,4 +100,4 @@ jobs:
       run: |
         cd ws
         source /opt/ros/eloquent/setup.bash
-        colcon test-results --verbose
+        colcon test-result --verbose

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
       run: |
         cd ws
         source /opt/ros/foxy/setup.bash
-        colcon test --packages-select traffic_editor
+        QT_QPA_PLATFORM=offscreen colcon test --packages-select traffic_editor
     - name: test-results
       shell: bash
       run: |
@@ -93,7 +93,7 @@ jobs:
       run: |
         cd ws
         source /opt/ros/eloquent/setup.bash
-        colcon test --packages-select traffic_editor
+        QT_QPA_PLATFORM=offscreen colcon test --packages-select traffic_editor
 
     - name: test-results
       shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
-name: build
+name: ci
 on: [push, pull_request]
 jobs:
-  build:
+  ci:
     runs-on: ubuntu-18.04
     container:
       image: docker://ros:eloquent-ros-base-bionic
@@ -39,7 +39,21 @@ jobs:
         source /opt/ros/eloquent/setup.bash
         colcon build --packages-select traffic_editor --cmake-args -DNO_DOWNLOAD_MODELS=True
 
-  build_without_plugin_support:
+    - name: test
+      shell: bash
+      run: |
+        cd ws
+        source /opt/ros/eloquent/setup.bash
+        colcon test --packages-select traffic_editor --cmake-args -DNO_DOWNLOAD_MODELS=True
+
+    - name: test-results
+      shell: bash
+      run: |
+        cd ws
+        source /opt/ros/eloquent/setup.bash
+        colcon test-results --verbose
+
+  ci_without_plugin_support:
     runs-on: ubuntu-18.04
     container:
       image: docker://ros:eloquent-ros-base-bionic
@@ -74,3 +88,17 @@ jobs:
         cd ws
         source /opt/ros/eloquent/setup.bash
         colcon build --packages-select traffic_editor --cmake-args -DNO_DOWNLOAD_MODELS=True
+
+    - name: test
+      shell: bash
+      run: |
+        cd ws
+        source /opt/ros/eloquent/setup.bash
+        colcon test --packages-select traffic_editor --cmake-args -DNO_DOWNLOAD_MODELS=True
+
+    - name: test-results
+      shell: bash
+      run: |
+        cd ws
+        source /opt/ros/eloquent/setup.bash
+        colcon test-results --verbose

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,9 +53,9 @@ jobs:
         colcon test-result --verbose
 
   ci_without_plugin_support:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container:
-      image: docker://ros:eloquent-ros-base-bionic
+      image: docker://ros:foxy-ros-base-focal
 
     steps:
     - name: osrf-repo
@@ -63,7 +63,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y wget
-        echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable bionic main" > /etc/apt/sources.list.d/gazebo-stable.list
+        echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable focal main" > /etc/apt/sources.list.d/gazebo-stable.list
         wget https://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
         sudo apt-get update
 
@@ -85,19 +85,19 @@ jobs:
       shell: bash
       run: |
         cd ws
-        source /opt/ros/eloquent/setup.bash
+        source /opt/ros/foxy/setup.bash
         colcon build --packages-select traffic_editor --cmake-args -DNO_DOWNLOAD_MODELS=True
 
     - name: test
       shell: bash
       run: |
         cd ws
-        source /opt/ros/eloquent/setup.bash
+        source /opt/ros/foxy/setup.bash
         QT_QPA_PLATFORM=offscreen colcon test --packages-select traffic_editor
 
     - name: test-results
       shell: bash
       run: |
         cd ws
-        source /opt/ros/eloquent/setup.bash
+        source /opt/ros/foxy/setup.bash
         colcon test-result --verbose

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![](https://github.com/osrf/traffic_editor/workflows/ci/badge.svg)
-![](https://github.com/osrf/traffic_editor/workflows/style/badge.svg)
+[![](https://github.com/osrf/traffic_editor/workflows/ci/badge.svg)](https://github.com/osrf/traffic_editor/actions/workflows/ci.yaml)
+[![](https://github.com/osrf/traffic_editor/workflows/style/badge.svg)](https://github.com/osrf/traffic_editor/actions/workflows/style.yaml)
 
 # traffic\_editor
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://github.com/osrf/traffic_editor/workflows/build/badge.svg)
+![](https://github.com/osrf/traffic_editor/workflows/ci/badge.svg)
 ![](https://github.com/osrf/traffic_editor/workflows/style/badge.svg)
 
 # traffic\_editor

--- a/traffic_editor/CMakeLists.txt
+++ b/traffic_editor/CMakeLists.txt
@@ -22,21 +22,28 @@ if(CMAKE_VERSION VERSION_LESS "3.7.0")
   set(CMAKE_INCLUDE_CURRENT_DIR ON)
 endif()
 
-find_package(Qt5 COMPONENTS Widgets Concurrent REQUIRED)
+find_package(Qt5 COMPONENTS Widgets Concurrent Test REQUIRED)
+find_package(ament_index_cpp REQUIRED)
+
 find_package(ignition-plugin1 QUIET COMPONENTS all)
 find_package(ignition-common3 QUIET)
-find_package(ament_index_cpp REQUIRED)
+if (ignition-plugin1_VERSION)
+  add_compile_definitions("HAS_IGNITION_PLUGIN")
+endif()
 
 # OpenCV is an optional dependency, only needed if you want to make videos
 # which is only really needed if you're using a process simulation plugin
 find_package(OpenCV QUIET)
+if (OpenCV_VERSION)
+  add_compile_definitions("HAS_OPENCV")
+endif()
 
 include_directories(.)
 include_directories(gui)
 include_directories(include)
 include_directories(${ament_index_cpp_INCLUDE_DIRS})
 
-set(traffic_editor_sources
+set(traffic_editor_gui_sources
   gui/actions/add_correspondence_point.cpp
   gui/actions/add_edge.cpp
   gui/actions/add_fiducial.cpp
@@ -70,7 +77,6 @@ set(traffic_editor_sources
   gui/lift_dialog.cpp
   gui/lift_door.cpp
   gui/lift_table.cpp
-  gui/main.cpp
   gui/map_view.cpp
   gui/model.cpp
   gui/model_dialog.cpp
@@ -90,7 +96,6 @@ set(traffic_editor_sources
   gui/traffic_map_dialog.cpp
   gui/vertex.cpp
   gui/yaml_utils.cpp
-  resources/resource.qrc
 
   #crowd_sim related
   gui/multi_select_combo_box.cpp
@@ -116,7 +121,7 @@ set(traffic_editor_sources
   gui/crowd_sim/transition_table.cpp
 )
 
-set(traffic_editor_libs
+set(traffic_editor_gui_libs
   Qt5::Widgets
   Qt5::Concurrent
   yaml-cpp
@@ -125,30 +130,30 @@ set(traffic_editor_libs
 )
 
 if (ignition-plugin1_VERSION)
-  set(traffic_editor_sources
-    ${traffic_editor_sources}
+  set(traffic_editor_gui_sources
+    ${traffic_editor_gui_sources}
     gui/sim_thread.cpp
   )
-  set(traffic_editor_libs
-    ${traffic_editor_libs}
+  set(traffic_editor_gui_libs
+    ${traffic_editor_gui_libs}
     ignition-plugin1::core
     ignition-plugin1::loader
     ignition-common3::core
   )
 endif()
 
-add_executable(traffic-editor ${traffic_editor_sources})
-target_link_libraries(traffic-editor ${traffic_editor_libs})
+add_library(
+  traffic_editor_gui STATIC
+  ${traffic_editor_gui_sources})
 
-if (ignition-plugin1_VERSION)
-  # sadly this if() block has to come after add_executable(), but
-  # the if() block determining the sources has to go before add_executable()
-  target_compile_definitions(traffic-editor PUBLIC "HAS_IGNITION_PLUGIN")
-endif()
+target_link_libraries(traffic_editor_gui ${traffic_editor_gui_libs})
 
-if (OpenCV_VERSION)
-  target_compile_definitions(traffic-editor PUBLIC "HAS_OPENCV")
-endif()
+add_executable(
+  traffic-editor
+  resources/resource.qrc
+  gui/main.cpp)
+
+target_link_libraries(traffic-editor traffic_editor_gui)
 
 set_property(TARGET traffic-editor PROPERTY ENABLE_EXPORTS 1)
 
@@ -170,6 +175,9 @@ install(
   DESTINATION
     include)
 
+if (BUILD_TESTING)
+  add_subdirectory(test)
+endif()
 
 ament_export_include_directories(include)
 

--- a/traffic_editor/CMakeLists.txt
+++ b/traffic_editor/CMakeLists.txt
@@ -28,14 +28,14 @@ find_package(ament_index_cpp REQUIRED)
 find_package(ignition-plugin1 QUIET COMPONENTS all)
 find_package(ignition-common3 QUIET)
 if (ignition-plugin1_VERSION)
-  add_compile_definitions("HAS_IGNITION_PLUGIN")
+  add_definitions(-DHAS_IGNITION_PLUGIN)
 endif()
 
 # OpenCV is an optional dependency, only needed if you want to make videos
 # which is only really needed if you're using a process simulation plugin
 find_package(OpenCV QUIET)
 if (OpenCV_VERSION)
-  add_compile_definitions("HAS_OPENCV")
+  add_definitions(-DHAS_OPENCV)
 endif()
 
 include_directories(.)

--- a/traffic_editor/gui/crowd_sim/transition_table.cpp
+++ b/traffic_editor/gui/crowd_sim/transition_table.cpp
@@ -111,7 +111,7 @@ void TransitionTab::_list_from_states_in_combo(
   connect(
     comboBox,
     &QComboBox::currentTextChanged,
-    [this](const QString& text)
+    [this](const QString& /*text*/)
     {
       save();
     }

--- a/traffic_editor/gui/multi_select_combo_box.cpp
+++ b/traffic_editor/gui/multi_select_combo_box.cpp
@@ -41,7 +41,7 @@ void MultiSelectComboBox::build_list()
 }
 
 
-void MultiSelectComboBox::box_checked(int state)
+void MultiSelectComboBox::box_checked(int /*state*/)
 {
   blockSignals(true);
   size_t list_count = pListWidget->count();

--- a/traffic_editor/test/CMakeLists.txt
+++ b/traffic_editor/test/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(
+  test_gui
+  ../resources/resource.qrc
+  test_gui.cpp)
+
+target_link_libraries(
+  test_gui
+  traffic_editor_gui
+  Qt5::Test
+)
+
+ament_add_test(
+  test_gui
+  COMMAND "$<TARGET_FILE:test_gui>" -o ${AMENT_TEST_RESULTS_DIR}/traffic_editor/test_gui.xml,xml -o -,txt
+  OUTPUT_FILE ${AMENT_TEST_RESULTS_DIR}/traffic_editor/test_gui/output.log
+)

--- a/traffic_editor/test/test_gui.cpp
+++ b/traffic_editor/test/test_gui.cpp
@@ -1,0 +1,31 @@
+#include <QtWidgets>
+#include <QTest>
+
+#include "../gui/editor.h"
+
+class TestGui : public QObject
+{
+  Q_OBJECT
+
+private:
+  Editor *editor = nullptr;
+
+private slots:
+  void initTestCase()
+  {
+    printf("initTestCase()\n");
+    editor = new Editor();
+  }
+  void testGui()
+  {
+    //QCOMPARE("a", "b");
+  }
+  void cleanupTestCase()
+  {
+    printf("cleanupTestCase()\n");
+    delete editor;
+  }
+};
+
+QTEST_MAIN(TestGui)
+#include "test_gui.moc"

--- a/traffic_editor/test/test_gui.cpp
+++ b/traffic_editor/test/test_gui.cpp
@@ -8,7 +8,7 @@ class TestGui : public QObject
   Q_OBJECT
 
 private:
-  Editor *editor = nullptr;
+  Editor* editor = nullptr;
 
 private slots:
   void initTestCase()


### PR DESCRIPTION
This PR reworks the `cmake` of the `traffic_editor` package to make it testable, and creates a minimal QTest:
 * move the GitHub workflows to `foxy` (they were on `eloquent` before)
 * create a static library for all of the sources other than `main.cpp`
 * builds the existing GUI by linking `main.cpp` with that static library (no change for users)
 * creates a minimal QTest, `test_gui.cpp` also with that static library, and register it in `ament_cmake` so that it runs with `colcon test` and dumps its output in (I think) a workable format and place. At least it seems to work as expected when I create a failing `QCOMPARE()` in QTest, reporting the failure as expected with all the nice QTest log info.
 * the minimal QTest just instantiates the `Editor` class and then deletes it, using the offscreen renderer so that it can run on GitHub CI. This doesn't really test anything, other than just making sure that the `Editor` constructor doesn't explode.
 * renames the `build` workflow to `ci` and actually runs `colcon test` and `colcon test-result` on it
 
The idea is that we can use this as a starting point to exercise the GUI in QTest, emulate GUI actions and clicks, and start getting some code coverage.