### PR TITLE
fixes #303, bug in loading/saving relative paths

### DIFF
--- a/traffic_editor/gui/building.cpp
+++ b/traffic_editor/gui/building.cpp
@@ -162,6 +162,11 @@ bool Building::save()
   YAML::Emitter emitter;
   yaml_utils::write_node(y, emitter);
   std::ofstream fout(filename);
+  if (!fout)
+  {
+    printf("unable to open %s\n", filename.c_str());
+    return false;
+  }
   fout << emitter.c_str() << std::endl;
 
   return true;

--- a/traffic_editor/gui/editor.cpp
+++ b/traffic_editor/gui/editor.cpp
@@ -503,7 +503,8 @@ Editor* Editor::get_instance()
 
 bool Editor::load_building(const QString& filename)
 {
-  if (!building.load(filename.toStdString()))
+  const QString absolute_path = QFileInfo(filename).absoluteFilePath();
+  if (!building.load(absolute_path.toStdString()))
     return false;
 
   level_idx = 0;
@@ -521,7 +522,7 @@ bool Editor::load_building(const QString& filename)
   update_tables();
 
   QSettings settings;
-  settings.setValue(preferences_keys::previous_building_path, filename);
+  settings.setValue(preferences_keys::previous_building_path, absolute_path);
 
   setWindowModified(false);
 
@@ -613,7 +614,7 @@ void Editor::building_new()
   QDir::setCurrent(dir_path);
 
   create_scene();
-  building.save();
+  building_save();
   update_tables();
 
   QSettings settings;
@@ -645,7 +646,14 @@ void Editor::building_open()
 
 bool Editor::building_save()
 {
-  building.save();
+  if (!building.save())
+  {
+    QMessageBox::critical(
+      this,
+      "Unable to save",
+      "Save failed! Maybe a bad path?");
+    return false;
+  }
   setWindowModified(false);
   return true;
 }


### PR DESCRIPTION
Relative paths were not being handled properly when loading and saving. Also, the `ofstream` object was not being checked for validity, so this was a silent error and edits would not be written to disk, resulting in much confusion. Now an error box will pop up if the `ofstream` is not pointing to an actual file, and the relative vs. absolute filename handling is fixed.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>