### PR TITLE
Disable crowd sim without failing

### DIFF
--- a/building_sim_plugins/building_gazebo_plugins/src/crowd_simulator.cpp
+++ b/building_sim_plugins/building_gazebo_plugins/src/crowd_simulator.cpp
@@ -36,7 +36,16 @@ void CrowdSimulatorPlugin::Load(
 
   if (!_crowd_sim_interface->read_sdf(sdf))
   {
+    RCLCPP_ERROR(_crowd_sim_interface->logger(),
+      "Error loading crowd simulator plugin. Load params failed!");
     exit(EXIT_FAILURE);
+  }
+
+  if (_crowd_sim_interface->enabled() == false)
+  {
+    RCLCPP_WARN(_crowd_sim_interface->logger(),
+      "CrowdSim is not enabled");
+    return;
   }
 
   if (!_crowd_sim_interface->init_crowd_sim())

--- a/building_sim_plugins/building_gazebo_plugins/src/crowd_simulator.cpp
+++ b/building_sim_plugins/building_gazebo_plugins/src/crowd_simulator.cpp
@@ -41,7 +41,7 @@ void CrowdSimulatorPlugin::Load(
     exit(EXIT_FAILURE);
   }
 
-  if (_crowd_sim_interface->enabled() == false)
+  if (!_crowd_sim_interface->enabled())
   {
     RCLCPP_WARN(_crowd_sim_interface->logger(),
       "CrowdSim is not enabled");

--- a/building_sim_plugins/building_ignition_plugins/src/crowd_simulator.cpp
+++ b/building_sim_plugins/building_ignition_plugins/src/crowd_simulator.cpp
@@ -51,7 +51,7 @@ void CrowdSimulatorPlugin::Configure(
     exit(EXIT_FAILURE);
   }
 
-  if (_crowd_sim_interface->enabled() == false)
+  if (!_crowd_sim_interface->enabled())
   {
     RCLCPP_WARN(_crowd_sim_interface->logger(),
       "CrowdSim is Disabled!");
@@ -80,6 +80,10 @@ void CrowdSimulatorPlugin::PreUpdate(
   const ignition::gazebo::UpdateInfo& info,
   ignition::gazebo::EntityComponentManager& ecm)
 {
+  // check if crowd sim is enabled
+  if (!_crowd_sim_interface->enabled())
+    return;
+
   // wait for all the models and actors loaded in ignition rendering
   if (!_initialized)
   {

--- a/building_sim_plugins/building_ignition_plugins/src/crowd_simulator.cpp
+++ b/building_sim_plugins/building_ignition_plugins/src/crowd_simulator.cpp
@@ -51,6 +51,13 @@ void CrowdSimulatorPlugin::Configure(
     exit(EXIT_FAILURE);
   }
 
+  if (_crowd_sim_interface->enabled() == false)
+  {
+    RCLCPP_WARN(_crowd_sim_interface->logger(),
+      "CrowdSim is Disabled!");
+    return;
+  }
+
   if (!_crowd_sim_interface->init_crowd_sim())
   {
     RCLCPP_ERROR(_crowd_sim_interface->logger(),

--- a/building_sim_plugins/building_plugins_common/src/crowd_simulator_common.cpp
+++ b/building_sim_plugins/building_plugins_common/src/crowd_simulator_common.cpp
@@ -158,6 +158,11 @@ void CrowdSimInterface::init_ros_node(const rclcpp::Node::SharedPtr node)
   _ros_node = std::move(node);
 }
 
+bool CrowdSimInterface::enabled() const
+{
+  return _enabled;
+}
+
 bool CrowdSimInterface::init_crowd_sim()
 {
   _menge_handle = MengeHandle::init_and_make(


### PR DESCRIPTION
Previously, if `MENGE_RESOURCE_PATH` is not provided, the `crowd_sim` plugin will fail, resulted in failing to launch a demo world. Instead of failing, the minor change here is to disable `crowd_sim` if `MENGE_RESOURCE_PATH` is not provided. 

With this, a subsequent pr will consist of an optional `use_crowdsim` arg (e.g.  `XX.launch.xml use_crowdsim:=1` ) in the demo world launch files. 
