### PR TITLE
fix lift model ele name conflict warning msg

### DIFF
--- a/rmf_building_map_tools/building_map/lift.py
+++ b/rmf_building_map_tools/building_map/lift.py
@@ -372,8 +372,8 @@ class Lift:
 
         pose = Element('pose')
         pose.text = f'{x} {y} {self.cabin_height / 2} 0 0 {yaw}'
-        platform.append(visual(name, pose, dims, lift_material()))
-        platform.append(collision(name, pose, dims, '0x01'))
+        platform.append(visual(f'{name}_visual', pose, dims, lift_material()))
+        platform.append(collision(f'{name}_collision', pose, dims, '0x01'))
 
     def generate_cabin(self, world_ele, options):
         # materials missing for now
@@ -398,15 +398,15 @@ class Lift:
 
         # visuals and collisions for floor and walls of cabin
         floor_dims = [self.width, self.depth, self.floor_thickness]
-        floor_name = 'floor'
         floor_pose = Element('pose')
         floor_pose.text = f'0 0 {-self.floor_thickness / 2} 0 0 0'
-        platform.append(visual(floor_name,
+        platform.append(visual("floor_visual",
                                floor_pose,
                                floor_dims,
                                lift_material()))
 
-        platform.append(collision(floor_name, floor_pose, floor_dims, '0x01'))
+        platform.append(
+            collision("floor_collision", floor_pose, floor_dims, '0x01'))
 
         # Wall generation
         # get each pair of end_points on each side, generate a section of wall


### PR DESCRIPTION
A simple fix to remove the non-unique names conflict warning https://github.com/open-rmf/rmf_demos/issues/73. This pr is targeting the fix on the Lift model, during lift cabin generation. 

```bash
...
[gzserver-19] [Msg] Connected to gazebo master @ http://127.0.0.1:11345
[gzserver-19] [Msg] Publicized address: 192.168.0.106
[gzserver-19] [Msg] Loading world file [/home/youliang/openrmf_ws/install/rmf_demos_maps/share/rmf_demos_maps/maps/hotel/hotel.world]
[gzserver-19] Error: Non-unique names detected in <link name='platform'>
[gzserver-19]   <inertial>
[gzserver-19]     <mass>1200</mass>
[gzserver-19]     <inertia>
[gzserver-19]       <ixx>729.25</ixx>
...
```
Basically, `<visual "name">` shouldn't be the same as `<collision "name">` in the sdf file.