### PR TITLE
Fix for issue #506

### DIFF
--- a/rmf_building_map_tools/building_map_server/building_map_server.py
+++ b/rmf_building_map_tools/building_map_server/building_map_server.py
@@ -283,7 +283,7 @@ class BuildingMapServer(Node):
         msg = Lift()
         # transformation is already done in Lift class
         msg.ref_x, msg.ref_y = lift.x, lift.y
-        msg.name = lift.name
+        msg.name = str(lift.name)
         msg.levels = lift.level_names
 
         msg.ref_yaw = lift.yaw


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug Fix :bug: :fist_left:  

### Fixed bug :bug: :red_circle: 

This fix resolves issue #506 which surfaces when a lift name only contains numerals. 

Due to how `.yaml` are generated via C++, numeral keys are stored without the necessary quotation, even when explicit stored as a string.

As a result, when loading the generated `.building.yaml` RMF map file into `building_map_server`, it will fail with the following runtime error:

```bash
File "/opt/ros/humble/local/lib/python3.10/dist-packages/rmf_building_map_msgs/msg/_lift.py", line 180, in name
assert \
AssertionError: The 'name' field must be of type 'str'
```

### Fix applied :fist_left: :green_circle: 

This fix explicitly cast the `lift.name` variable in `building_map_server.py` to a string and avoiding the Assertion Error as highlighted above.