### PR TITLE
Fix for issue #462

### DIFF
--- a/rmf_building_map_tools/building_map_server/building_map_server.py
+++ b/rmf_building_map_tools/building_map_server/building_map_server.py
@@ -195,10 +195,7 @@ class BuildingMapServer(Node):
             graph_msg.name = str(i)  # todo: someday, string names...
             print(f"graph {i} has {len(g['vertices'])} vertices")
             for v in g['vertices']:
-                gn = GraphNode()
-                gn.x = v[0]
-                gn.y = v[1]
-                gn.name = v[2]['name']
+                gn = self.create_graph_node(v[0], v[1], v[2]['name'])
 
                 # add specific params to builidng_map_msg
                 for str_param in ["dock_name",
@@ -245,10 +242,7 @@ class BuildingMapServer(Node):
         wall_graph = level.generate_wall_graph()
         msg.wall_graph.name = "WallGraph"
         for v in wall_graph['vertices']:
-            gn = GraphNode()
-            gn.x = v[0]
-            gn.y = v[1]
-            gn.name = str(v[2]['name'])
+            gn = self.create_graph_node(v[0], v[1], v[2]['name'])
 
             # Ignore any other vertex params - not needed for wall graph
             msg.wall_graph.vertices.append(gn)
@@ -323,6 +317,14 @@ class BuildingMapServer(Node):
         # todo: only include images/graphs if they are requested?
         response.building_map = self.map_msg
         return response
+
+    def create_graph_node(self, wp_x, wp_y, wp_name):
+        gn = GraphNode()
+        gn.x = wp_x
+        gn.y = wp_y
+        gn.name = str(wp_name)
+
+        return gn
 
 
 def main():

--- a/rmf_building_map_tools/building_map_server/building_map_server.py
+++ b/rmf_building_map_tools/building_map_server/building_map_server.py
@@ -248,7 +248,7 @@ class BuildingMapServer(Node):
             gn = GraphNode()
             gn.x = v[0]
             gn.y = v[1]
-            gn.name = v[2]['name']
+            gn.name = str(v[2]['name'])
 
             # Ignore any other vertex params - not needed for wall graph
             msg.wall_graph.vertices.append(gn)


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug Fix :bug: :fist_left:  

### Fixed bug :bug: :red_circle: 

This fix resolves issue #462 which surfaces when a waypoint name only contains numerals. 

Due to how `.yaml` are generated via C++, numeral keys are stored without the necessary quotation, even when explicit stored as a string.

As a result, when loading the generated `.building.yaml` RMF map file into `building_map_server`, it will fail with the following runtime error:

```bash
File "/opt/ros/humble/local/lib/python3.10/dist-packages/rmf_building_map_msgs/msg/_graph_node.py", line 180, in name
assert \
AssertionError: The 'name' field must be of type 'str'
```

### Fix applied :fist_left: :green_circle: 

This fix explicitly cast the `v[2]['name']` variable in `building_map_server.py` to a string and avoiding the Assertion Error as highlighted above.