### PR TITLE
Adding "mutex" to vertex and lane param

### DIFF
--- a/rmf_building_map_tools/building_map_server/building_map_server.py
+++ b/rmf_building_map_tools/building_map_server/building_map_server.py
@@ -200,7 +200,8 @@ class BuildingMapServer(Node):
                 # add specific params to builidng_map_msg
                 for str_param in ["dock_name",
                                   "pickup_dispenser",
-                                  "dropoff_ingestor"]:
+                                  "dropoff_ingestor",
+                                  "mutex"]:
                     if (str_param in v[2]):
                         p = Param()
                         p.name = str_param
@@ -234,6 +235,12 @@ class BuildingMapServer(Node):
                     p.name = "speed_limit"
                     p.type = p.TYPE_DOUBLE
                     p.value_float = float(lane[2]["speed_limit"])
+                    ge.params.append(p)
+                if "mutex" in lane[2]:
+                    p = Param()
+                    p.name = "mutex"
+                    p.type = p.TYPE_STRING
+                    p.value_string = lane[2]["mutex"]
                     ge.params.append(p)
                 graph_msg.edges.append(ge)
             msg.nav_graphs.append(graph_msg)


### PR DESCRIPTION
I am creating a feature for a read-only fleet to be able to obtain and release mutexes from the mutex supervisor.

As of this moment, the workflow embeds the mutex parameters in the full-control fleet adapter and cannot be found dynamically in both `/map` and `/nav_graph` topics.

What I have done here is to add the parsing of `mutex` properties in the `rmf_building_map_server`.

For which the read-only adapter will get the available mutex entities and their location, and request whenever its robots are near a specific mutex entity.