### PR TITLE
Fix bug in angle difference calculation near ±π

### DIFF
--- a/rmf_traffic_editor/CMakeLists.txt
+++ b/rmf_traffic_editor/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(Ceres REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(Qt5 COMPONENTS Widgets Concurrent Test Network REQUIRED)
 find_package(yaml-cpp REQUIRED)
+find_package(rmf_utils REQUIRED)
 
 set(CMAKE_BUILD_TYPE RelWithDebInfo)
 # set(CMAKE_VERBOSE_MAKEFILE TRUE)
@@ -123,6 +124,7 @@ target_link_libraries(
   Qt5::Network
   proj
   yaml-cpp
+  rmf_utils::rmf_utils
   ${ament_index_cpp_LIBRARIES}
 )
 
@@ -155,7 +157,6 @@ install(
 
 if (BUILD_TESTING)
   find_package(ament_cmake_uncrustify REQUIRED)
-  find_package(rmf_utils REQUIRED)
 
   add_subdirectory(test)
 

--- a/rmf_traffic_editor/gui/building.cpp
+++ b/rmf_traffic_editor/gui/building.cpp
@@ -548,7 +548,13 @@ Building::Transform Building::compute_transform(
   // it is a crude method for now, but we will just compute the mean of the angles of all the fiducial pairs
   double relative_rotation_sum = 0;
   for (std::size_t i = 0; i < rotations.size(); i++)
-    relative_rotation_sum += rotations[i].first - rotations[i].second;
+  {
+    // calculate shortest angle diff between two angles
+    double diff = rotations[i].first - rotations[i].second;
+    while (diff <= -M_PI) diff += 2.0 * M_PI;
+    while (diff >  M_PI)  diff -= 2.0 * M_PI;
+    relative_rotation_sum += diff;
+  }
   const double rotation = relative_rotation_sum / rotations.size();
 
   // calculate the distances between each fiducial on their levels

--- a/rmf_traffic_editor/gui/building.cpp
+++ b/rmf_traffic_editor/gui/building.cpp
@@ -27,6 +27,8 @@
 #include <QtConcurrent/QtConcurrent>
 #include <QElapsedTimer>
 
+#include <rmf_utils/math.hpp>
+
 #include "building.h"
 #include "yaml_utils.h"
 
@@ -551,9 +553,7 @@ Building::Transform Building::compute_transform(
   {
     // calculate shortest angle diff between two angles
     double diff = rotations[i].first - rotations[i].second;
-    while (diff <= -M_PI) diff += 2.0 * M_PI;
-    while (diff >  M_PI)  diff -= 2.0 * M_PI;
-    relative_rotation_sum += diff;
+    relative_rotation_sum += rmf_utils::wrap_to_pi(diff);
   }
   const double rotation = relative_rotation_sum / rotations.size();
 


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug

<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

This PR fixes a bug in the rotation transformation logic where angle differences were calculated using simple subtraction without accounting for angle wraparound in the [-π, π] range.

In the original implementation, the angular difference between two orientations (calculated using atan2) was computed like this:
`double angle_diff = angle1 - angle2;`

This approach fails when the two angles are numerically far apart but spatially very close due to wraparound.
For example:
```
angle1 = 0.9π
angle2 = -0.9π
```
A simple subtraction results in:
`angle_diff = 0.9π - (-0.9π) = 1.8π`

However, geometrically, these two angles are very close — the actual shortest angular distance should be -0.2π .

This leads to large, incorrect relative_rotation_sum, and causes wrong rotation transformation `const double rotation = relative_rotation_sum / rotations.size();`.

### Fix applied

The fix introduces normalization of the angle difference into the range [-π, π]:
```
double diff = rotations[i].first - rotations[i].second;
while (diff <= -M_PI) diff += 2.0 * M_PI;
while (diff >  M_PI)  diff -= 2.0 * M_PI;
relative_rotation_sum += diff;
```

This ensures the smallest angular distance is always used (in the range [-π, π]), resolving errors caused by direct subtraction.


<!-- Describe in detail the approach taken, tools used, etc. to identify the cause of the bug and what was done to fix it. -->

