### PR TITLE
Enabled Delete property button to the custom parameters in vertices GUI

### DIFF
--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -232,9 +232,24 @@ Editor::Editor()
   property_editor->verticalHeader()->setSectionResizeMode(
     QHeaderView::ResizeToContents);
   property_editor->setAutoFillBackground(true);
+  property_editor->setSelectionBehavior(QAbstractItemView::SelectRows);
   connect(
     property_editor, &QTableWidget::cellChanged,
     this, &Editor::property_editor_cell_changed);
+  connect(
+    property_editor, &QTableWidget::itemSelectionChanged,
+    [this]()
+    {
+      const int row = property_editor->currentRow();
+      if (row < 0)
+      {
+        delete_param_button->setEnabled(false);
+        return;
+      }
+      QTableWidgetItem* item = property_editor->item(row, 0);
+      delete_param_button->setEnabled(
+        item && item->data(Qt::UserRole).toBool());
+    });
 
   QHBoxLayout* param_button_layout = new QHBoxLayout;
 
@@ -1355,10 +1370,31 @@ void Editor::add_param_button_clicked()
 
 void Editor::delete_param_button_clicked()
 {
-  QMessageBox::about(
-    this,
-    "work in progress",
-    "TODO: something...sorry. For now, hand-edit the YAML.");
+  const int row = property_editor->currentRow();
+  if (row < 0)
+    return;
+
+  QTableWidgetItem* name_item = property_editor->item(row, 0);
+  if (!name_item)
+    return;
+
+  const std::string param_name = name_item->text().toStdString();
+
+  for (size_t i = 0; i < building.levels[level_idx].vertices.size(); i++)
+  {
+    Vertex& v = building.levels[level_idx].vertices[i];
+    if (!v.selected)
+      continue;
+
+    auto it = v.params.find(param_name);
+    if (it != v.params.end())
+    {
+      v.params.erase(it);
+      populate_property_editor(v, i);
+      setWindowModified(true);
+      return;
+    }
+  }
 }
 
 void Editor::layer_edit_button_clicked(const int row_idx)
@@ -1543,11 +1579,15 @@ void Editor::populate_property_editor(const Vertex& vertex, const int index)
       QString::fromStdString(param.first),
       param.second.to_qstring(),
       true);
+    // mark this row as a deletable param so itemSelectionChanged can detect it
+    property_editor->item(row, 0)->setData(Qt::UserRole, true);
     row++;
   }
 
   add_param_button->setEnabled(true);
   add_param_button->setProperty("object_type", QVariant("vertex"));
+  delete_param_button->setProperty("object_type", QVariant("vertex"));
+  // delete_param_button enable state is managed by itemSelectionChanged
 
   property_editor->blockSignals(false);  // re-enable callbacks
 }

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -700,7 +700,7 @@ void Editor::restore_previous_viewport()
 bool Editor::eventFilter(QObject* obj, QEvent* event)
 {
   if (obj == property_editor->viewport() &&
-      event->type() == QEvent::MouseButtonPress)
+    event->type() == QEvent::MouseButtonPress)
   {
     QMouseEvent* me = static_cast<QMouseEvent*>(event);
     QModelIndex idx = property_editor->indexAt(me->pos());

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -214,6 +214,7 @@ Editor::Editor()
   right_tab_widget->addTab(crowd_sim_table, "crowds");
 
   property_editor = new QTableWidget;
+  property_editor->viewport()->installEventFilter(this);
   property_editor->setStyleSheet(
     "QTableWidget { background-color: #e0e0e0; color: black; gridline-color: #606060; } QLineEdit { background:white; }");
   property_editor->setMinimumSize(600, 200);
@@ -694,6 +695,24 @@ void Editor::restore_previous_viewport()
     printf("resetting view...\n");
     zoom_reset();
   }
+}
+
+bool Editor::eventFilter(QObject* obj, QEvent* event)
+{
+  if (obj == property_editor->viewport() &&
+      event->type() == QEvent::MouseButtonPress)
+  {
+    QMouseEvent* me = static_cast<QMouseEvent*>(event);
+    QModelIndex idx = property_editor->indexAt(me->pos());
+    if (!idx.isValid())
+    {
+      // clicking the empty space would clear the selection
+      property_editor->clearSelection();
+      property_editor->setCurrentIndex(QModelIndex());
+      delete_param_button->setEnabled(false);
+    }
+  }
+  return QMainWindow::eventFilter(obj, event);
 }
 
 bool Editor::load_previous_building()

--- a/rmf_traffic_editor/gui/editor.cpp
+++ b/rmf_traffic_editor/gui/editor.cpp
@@ -1391,7 +1391,10 @@ void Editor::delete_param_button_clicked()
     {
       v.params.erase(it);
       populate_property_editor(v, i);
+      property_editor->clearSelection(); // prevents itemSelectionChanged re-enabling it
+      delete_param_button->setEnabled(false);
       setWindowModified(true);
+      create_scene();
       return;
     }
   }

--- a/rmf_traffic_editor/gui/editor.h
+++ b/rmf_traffic_editor/gui/editor.h
@@ -92,6 +92,9 @@ public:
   /// Attempt to restore the previous viewport scale and center point
   void restore_previous_viewport();
 
+  /// Event filter to catch mouse events on the map view and handle them in the editor
+  bool eventFilter(QObject* obj, QEvent* event) override;
+
 protected:
   void mousePressEvent(QMouseEvent* e);
   void mouseReleaseEvent(QMouseEvent* e);


### PR DESCRIPTION
## New feature implementation

### Implemented feature

In the traffic-editor GUI, a user can add a property, just by clicking on the `Add property...` button.
However, on the other side, the `Delete property` does not work if the user wants to delete a custom parameter. This button seems disabled, with just a TODO in the [gui/editor.cpp](https://github.com/open-rmf/rmf_traffic_editor/blob/main/rmf_traffic_editor/gui/editor.cpp#L1356C1-L1362C2) and a message to invite the user to modify by hand the YAML.
This feature solves that TODO code section in a few ways:

- add `setSelectionBehavior(QAbstractItemView::SelectRows)` in order to highlights the whole row and make it clear to the user which params to delete.
 
- `connect(property_editor, &QTableWidget::itemSelectionChanged,[this](){...})` whenever the user select a new item, the connect() checks if the column 0 of the current row has `Qt::UserRole == true`. If yes, the button is enabled; otherwise, it stays disabled.
 
- only the custom params rows get the flag `Qt::UserRole == true`. This allows to delete only the custom parameters, and not touching the default ones.

- only the specific property in the .building.yaml file will be deleted.

### Implementation description

Below a picture of a **no removable param** in GUI:

<img width="1920" height="1080" alt="traffic_editor_not_removable_param" src="https://github.com/user-attachments/assets/10901673-f22d-4371-957e-dc2d30116f4b" />

And here a picture of a **removable param** in GUI:

<img width="1920" height="1080" alt="traffic_editor_removable_param" src="https://github.com/user-attachments/assets/9e5f2544-ca58-4d78-b596-a6fab93d0650" />

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI